### PR TITLE
SIMPLY-2949: Show 'Chapter n' in TOC for spine items without titles.

### DIFF
--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSpineElementType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSpineElementType.kt
@@ -53,7 +53,7 @@ interface PlayerSpineElementType {
    * The title of the spine item.
    */
 
-  val title: String
+  val title: String?
 
   /**
    * The player position for the start of the spine item. This position may be used to play

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoManifest.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoManifest.kt
@@ -47,7 +47,7 @@ data class ExoManifest(
     ): ExoManifestSpineItem {
 
       val title =
-        item.title ?: index.toString()
+        item.title
       val type =
         item.type ?: this.OCTET_STREAM
       val uri =

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoManifestSpineItem.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoManifestSpineItem.kt
@@ -9,7 +9,7 @@ import java.net.URI
  */
 
 data class ExoManifestSpineItem(
-  val title: String,
+  val title: String?,
   val part: Int,
   val chapter: Int,
   val type: MIMEType,

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
@@ -64,7 +64,7 @@ class ExoSpineElement(
       0
     )
 
-  override val title: String
+  override val title: String?
     get() = this.itemManifest.title
 
   private val downloadTask: PlayerDownloadTaskType =

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCAdapter.kt
@@ -79,8 +79,14 @@ class PlayerTOCAdapter(
     UIThread.checkIsUIThread()
 
     val item = this.spineElements[position]
+    val normalIndex = item.index + 1
 
-    holder.titleText.text = item.title
+    val title = item.title ?: this.context.getString(
+      R.string.audiobook_player_toc_chapter_n,
+      normalIndex
+    )
+
+    holder.titleText.text = title
     holder.titleText.isEnabled = false
 
     if (item.book.supportsStreaming) {
@@ -93,7 +99,6 @@ class PlayerTOCAdapter(
       holder.view.isEnabled = false
     }
 
-    val normalIndex = item.index + 1
     var requiresDownload = false
     var failedDownload = false
     var downloading = false
@@ -210,7 +215,7 @@ class PlayerTOCAdapter(
     view.contentDescription =
       contentDescriptionOf(
         resources = context.resources,
-        title = item.title,
+        title = title,
         duration = item.duration,
         playing = position == this.currentSpineElement,
         requiresDownload = requiresDownload,

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
   <string name="audiobook_player_waiting">Chapter %1$d must be downloaded to continue playback.</string>
   <string name="audiobook_player_error">An error occurred during playback. Error code: %1$d</string>
 
+  <string name="audiobook_player_toc_chapter_n">Chapter %1$d</string>
   <string name="audiobook_player_toc_menu_refresh_all">Refresh All</string>
   <string name="audiobook_player_toc_menu_stop_all">Stop All Downloads</string>
   <string name="audiobook_player_toc_menu_stop_all_confirm">Stop all downloads?</string>


### PR DESCRIPTION
**What's this do?**

Show "Chapter _n_" in the table of contents when a spine item does not have a title. Currently, the 0-based index number of the item is shown. Specifically, in ExoManifest.kt, the title is set to the index number: https://github.com/NYPL-Simplified/audiobook-android/blob/ea72bba4b24971421ec8c3ba2246364c00ab4cbe/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoManifest.kt#L49-L50

Rather than setting the title there when it is not present in the raw manifest, I'm allowing it to be null, and pushing the logic of what to display out to the view layer. In PlayerTOCAdapter.kt, if the title is null, I format a string resource with the index number, similarly to other strings in that class. 

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2949](https://jira.nypl.org/browse/SIMPLY-2949).

**How should this be tested? / Do these changes have associated tests?**

Download an Overdrive audio book, for example in the NYPL QA library, "Glory Was I Had Such Friends" or "Special Deluxe". Open the Table of Contents. The items should be labeled as "Chapter _n_" (starting with "Chapter 1"), instead of just a number (starting with "0").

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran the vanilla app with this in place.