### PR TITLE
Implement Feedbooks signature check.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ ext.libraries = [
   logbackAndroid          : "com.github.tony19:logback-android:2.0.0",
   logbackClassic          : "ch.qos.logback:logback-classic:1.3.0-alpha4",
   mockito                 : "org.mockito:mockito-core:2.27.0",
+  nimbusJoseJWT           : "com.nimbusds:nimbus-jose-jwt:8.20",
   okhttp                  : "com.squareup.okhttp3:okhttp:3.14.1",
   quicktheories           : 'org.quicktheories:quicktheories:0.26',
   rxjava                  : "io.reactivex:rxjava:1.3.8",

--- a/org.librarysimplified.audiobook.feedbooks/build.gradle
+++ b/org.librarysimplified.audiobook.feedbooks/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   implementation libraries.irradiaFieldrushAPI
   implementation libraries.irradiaFieldrushVanilla
   implementation libraries.kotlinStdlib
+  implementation libraries.nimbusJoseJWT
   implementation libraries.okhttp
   implementation libraries.slf4j
 }

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/CertificateRetrievalException.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/CertificateRetrievalException.kt
@@ -1,0 +1,3 @@
+package org.librarysimplified.audiobook.feedbooks
+
+class CertificateRetrievalException() : Exception()

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureCheck.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureCheck.kt
@@ -2,15 +2,36 @@ package org.librarysimplified.audiobook.feedbooks
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.util.Base64
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import org.librarysimplified.audiobook.json_canon.JSONCanonicalization
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckResult
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckStatus
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckType
+import org.slf4j.LoggerFactory
+import java.io.IOException
+import java.net.URL
+import java.security.Signature
+import java.text.ParseException
 
 class FeedbooksSignatureCheck(
+  private val httpClient: OkHttpClient,
   private val parameters: SingleLicenseCheckParameters
 ) : SingleLicenseCheckType {
+
+  private val logger =
+    LoggerFactory.getLogger(FeedbooksSignatureCheck::class.java)
+
+  /*
+   * Map issuer URI to certificate URL.
+   */
+  private val issuers = mapOf(
+    "https://www.cantookaudio.com" to "https://listen.cantookaudio.com/.well-known/jwks.json"
+  );
 
   override fun execute(): SingleLicenseCheckResult {
     this.event("Started check")
@@ -22,21 +43,127 @@ class FeedbooksSignatureCheck(
         ?: return SingleLicenseCheckResult.NotApplicable("No signature information supplied.")
 
     this.event("Deserializing manifest bytes")
+
     val objectMapper = ObjectMapper()
     val objectNode = objectMapper.readTree(this.parameters.manifest.originalBytes) as ObjectNode
-    objectNode.remove("http://www.feedbooks.com/audiobooks/signature")
 
-    val metaNode = objectNode["metadata"]
-    if (metaNode is ObjectNode) {
-      metaNode.remove("http://www.feedbooks.com/audiobooks/signature")
+    this.event("Extracting signature from manifest")
+
+    val metadataNode = objectNode["metadata"]
+
+    if (metadataNode is ObjectNode) {
+      metadataNode.remove("http://www.feedbooks.com/audiobooks/signature")
     }
 
     this.event("Canonicalizing manifest")
-    val canonBytes = JSONCanonicalization.canonicalize(objectNode)
 
-    System.out.println(String(canonBytes))
+    val canonicalManifestBytes = JSONCanonicalization.canonicalize(objectNode)
 
-    return SingleLicenseCheckResult.NotApplicable("Not implemented!")
+    this.event("Checking signature")
+
+    return try {
+      checkSignature(canonicalManifestBytes, signature)
+    }
+    catch (e: UnsupportedAlgorithmException) {
+      SingleLicenseCheckResult.Failed(e.message ?: "Unsupported signature algorithm.")
+    }
+    catch (e: UnknownIssuerException) {
+      SingleLicenseCheckResult.Failed(e.message ?: "Unknown signature issuer.")
+    }
+    catch (e: CertificateRetrievalException) {
+      SingleLicenseCheckResult.Failed("Certificate could not be retrieved.")
+    }
+    catch (e: ParseException) {
+      SingleLicenseCheckResult.Failed("Certificate could not be parsed.")
+    }
+  }
+
+  private fun checkSignature(
+    manifestBytes: ByteArray,
+    signature: FeedbooksSignature
+  ): SingleLicenseCheckResult {
+    val certificate = retrieveCertificate(signature)
+
+    if (verifySignatureWithCertificate(certificate, manifestBytes, signature)) {
+      return SingleLicenseCheckResult.Succeeded("Signature verified.")
+    }
+
+    return SingleLicenseCheckResult.Failed("Signature not verified.")
+  }
+
+  private fun verifySignatureWithCertificate(
+    certificateBytes: ByteArray,
+    manifestBytes: ByteArray,
+    signature: FeedbooksSignature
+  ): Boolean {
+    val keySet = JWKSet.parse(String(certificateBytes, Charsets.UTF_8))
+
+    return keySet.keys.any({ key -> verifySignatureWithKey(key, manifestBytes, signature) })
+  }
+
+  private fun verifySignatureWithKey(
+    key: JWK,
+    manifestBytes: ByteArray,
+    signature: FeedbooksSignature
+  ): Boolean {
+    when (val algorithm = signature.algorithm) {
+      "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256" -> {
+        val publicKey = key.toRSAKey().toPublicKey()
+        val verifier = Signature.getInstance("SHA256withRSA")
+
+        verifier.initVerify(publicKey)
+        verifier.update(manifestBytes)
+
+        return verifier.verify(Base64.from(signature.value).decode())
+      }
+      else -> {
+        throw UnsupportedAlgorithmException("Unsupported signature algorithm ${algorithm}.")
+      }
+    }
+  }
+
+  private fun retrieveCertificate(
+    signature: FeedbooksSignature
+  ): ByteArray {
+    val certificateURL = getCertificateURL(signature.issuer)
+
+    this.event("Retrieving certificate ${certificateURL}...");
+
+    val request =
+      Request.Builder()
+        .url(certificateURL)
+        .header("User-Agent", this.parameters.userAgent.userAgent)
+        .build()
+
+    try {
+      this.httpClient.newCall(request).execute().use { response ->
+        this.logger.debug("response: {} {}", response.code(), response.message())
+
+        if (!response.isSuccessful) {
+          this.event("Error downloading certificate (${response.code()})")
+
+          throw CertificateRetrievalException()
+        }
+
+        val bodyBytes = response.body()?.bytes() ?: ByteArray(0)
+        this.logger.debug("received {} bytes", bodyBytes.size)
+
+        return bodyBytes;
+      }
+    }
+    catch (e: IOException) {
+      throw CertificateRetrievalException()
+    }
+  }
+
+  private fun getCertificateURL(issuerURI: String?): URL {
+    val certificateUrl = issuers[issuerURI]
+
+    if (certificateUrl == null) {
+      throw UnknownIssuerException("Unknown signature issuer ${issuerURI}.")
+    }
+
+    return URL(certificateUrl)
   }
 
   private fun event(message: String) {

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureCheck.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureCheck.kt
@@ -22,14 +22,19 @@ class FeedbooksSignatureCheck(
         ?: return SingleLicenseCheckResult.NotApplicable("No signature information supplied.")
 
     this.event("Deserializing manifest bytes")
-    val objectMapper =
-      ObjectMapper()
-    val objectNode =
-      objectMapper.readTree(this.parameters.manifest.originalBytes) as ObjectNode
+    val objectMapper = ObjectMapper()
+    val objectNode = objectMapper.readTree(this.parameters.manifest.originalBytes) as ObjectNode
     objectNode.remove("http://www.feedbooks.com/audiobooks/signature")
+
+    val metaNode = objectNode["metadata"]
+    if (metaNode is ObjectNode) {
+      metaNode.remove("http://www.feedbooks.com/audiobooks/signature")
+    }
 
     this.event("Canonicalizing manifest")
     val canonBytes = JSONCanonicalization.canonicalize(objectNode)
+
+    System.out.println(String(canonBytes))
 
     return SingleLicenseCheckResult.NotApplicable("Not implemented!")
   }

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureChecks.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/FeedbooksSignatureChecks.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.feedbooks
 
+import org.librarysimplified.audiobook.http.AudioBookHTTPClients
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckProviderType
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckType
@@ -12,6 +13,9 @@ class FeedbooksSignatureChecks : SingleLicenseCheckProviderType {
   override fun createLicenseCheck(
     parameters: SingleLicenseCheckParameters
   ): SingleLicenseCheckType {
-    return FeedbooksSignatureCheck(parameters)
+    return FeedbooksSignatureCheck(
+      httpClient = AudioBookHTTPClients.cachingClient(parameters.cacheDirectory),
+      parameters = parameters
+    )
   }
 }

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/UnknownIssuerException.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/UnknownIssuerException.kt
@@ -1,0 +1,3 @@
+package org.librarysimplified.audiobook.feedbooks
+
+class UnknownIssuerException(message: String?) : Exception(message)

--- a/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/UnsupportedAlgorithmException.kt
+++ b/org.librarysimplified.audiobook.feedbooks/src/main/java/org/librarysimplified/audiobook/feedbooks/UnsupportedAlgorithmException.kt
@@ -1,0 +1,3 @@
+package org.librarysimplified.audiobook.feedbooks
+
+class UnsupportedAlgorithmException(message: String?) : Exception(message)

--- a/org.librarysimplified.audiobook.http/src/main/java/org/librarysimplified/audiobook/http/AudioBookHTTPClients.kt
+++ b/org.librarysimplified.audiobook.http/src/main/java/org/librarysimplified/audiobook/http/AudioBookHTTPClients.kt
@@ -1,7 +1,9 @@
 package org.librarysimplified.audiobook.http
 
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import org.slf4j.LoggerFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 /**
@@ -20,10 +22,41 @@ object AudioBookHTTPClients {
       .addInterceptor(AudioBookHTTPInterceptor(this.logger))
       .build()
 
+  private val cachingClients: HashMap<String, OkHttpClient> = hashMapOf()
+
   /**
    * The default HTTP client.
    */
 
   fun defaultClient(): OkHttpClient =
     this.defaultClient
+
+  /**
+   * A caching HTTP client.
+   */
+
+  fun cachingClient(cacheDirectory: File): OkHttpClient {
+    // If a client has already been configured for the given cache directory, return it.
+
+    val cachePath = cacheDirectory.canonicalPath
+    val client = cachingClients[cachePath]
+
+    if (client != null) {
+      return client;
+    }
+
+    // Otherwise, configure a caching client based on the default client, and memoize it.
+
+    return defaultClient.newBuilder()
+      .cache(Cache(
+        File(cacheDirectory, "audiobook-http"),
+        // A small (16 KB) cache should suffice, as the cache is currently only used for a feedbooks
+        // certificate (about 1 KB).
+        16L * 1024L
+      ))
+      .build()
+      .also {
+        cachingClients.put(cachePath, it)
+      }
+  }
 }

--- a/org.librarysimplified.audiobook.json_canon/src/main/java/org/librarysimplified/audiobook/json_canon/JSONCanonicalization.kt
+++ b/org.librarysimplified.audiobook.json_canon/src/main/java/org/librarysimplified/audiobook/json_canon/JSONCanonicalization.kt
@@ -1,8 +1,6 @@
 package org.librarysimplified.audiobook.json_canon
 
-import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.node.ObjectNode
 import java.io.ByteArrayOutputStream
@@ -25,10 +23,11 @@ object JSONCanonicalization {
     outputStream: OutputStream
   ) {
     val mapper = ObjectMapper()
+    val map = mapper.treeToValue(objectNode, Map::class.java)
+
     mapper.configure(SerializationFeature.INDENT_OUTPUT, false)
-    mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
-    mapper.writeValue(outputStream, objectNode)
+    mapper.writeValue(outputStream, map)
   }
 
   /**

--- a/org.librarysimplified.audiobook.json_canon/src/main/java/org/librarysimplified/audiobook/json_canon/JSONCanonicalization.kt
+++ b/org.librarysimplified.audiobook.json_canon/src/main/java/org/librarysimplified/audiobook/json_canon/JSONCanonicalization.kt
@@ -1,6 +1,8 @@
 package org.librarysimplified.audiobook.json_canon
 
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationConfig
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.node.ObjectNode
 import java.io.ByteArrayOutputStream
@@ -24,6 +26,7 @@ object JSONCanonicalization {
   ) {
     val mapper = ObjectMapper()
     mapper.configure(SerializationFeature.INDENT_OUTPUT, false)
+    mapper.configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true)
     mapper.writeValue(outputStream, objectNode)
   }

--- a/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheck.kt
+++ b/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheck.kt
@@ -31,7 +31,8 @@ internal class LicenseCheck internal constructor(
             SingleLicenseCheckParameters(
               manifest = this.parameters.manifest,
               userAgent = this.parameters.userAgent,
-              onStatusChanged = this.eventSubject::onNext
+              onStatusChanged = this.eventSubject::onNext,
+              cacheDirectory = this.parameters.cacheDirectory
             )
           )
         singleCheck.execute()

--- a/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheckParameters.kt
+++ b/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheckParameters.kt
@@ -3,6 +3,7 @@ package org.librarysimplified.audiobook.license_check.api
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckProviderType
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
+import java.io.File
 
 /**
  * The parameters for a set of license checks.
@@ -26,5 +27,11 @@ data class LicenseCheckParameters(
    * The list of license checks that will be evaluated.
    */
 
-  val checks: List<SingleLicenseCheckProviderType>
+  val checks: List<SingleLicenseCheckProviderType>,
+
+  /**
+   * The directory in which to store cache files.
+   */
+
+  val cacheDirectory: File
 )

--- a/org.librarysimplified.audiobook.license_check.spi/src/main/java/org/librarysimplified/audiobook/license_check/spi/SingleLicenseCheckParameters.kt
+++ b/org.librarysimplified.audiobook.license_check.spi/src/main/java/org/librarysimplified/audiobook/license_check/spi/SingleLicenseCheckParameters.kt
@@ -2,6 +2,7 @@ package org.librarysimplified.audiobook.license_check.spi
 
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
+import java.io.File
 
 /**
  * The parameters for a single license check.
@@ -25,5 +26,11 @@ data class SingleLicenseCheckParameters(
    * A function that will receive the results of license checking.
    */
 
-  val onStatusChanged: (SingleLicenseCheckStatus) -> Unit
+  val onStatusChanged: (SingleLicenseCheckStatus) -> Unit,
+
+  /**
+   * The directory in which to store cache files.
+   */
+
+  val cacheDirectory: File
 )

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksRightsCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksRightsCheckContract.kt
@@ -3,7 +3,9 @@ package org.librarysimplified.audiobook.tests
 import org.joda.time.LocalDateTime
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.feedbooks.FeedbooksRightsCheck
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
@@ -23,6 +25,10 @@ abstract class FeedbooksRightsCheckContract {
 
   abstract fun log(): Logger
 
+  @Rule
+  @JvmField
+  val tempFolder = TemporaryFolder()
+
   @Before
   fun testSetup() {
     this.eventLog = mutableListOf()
@@ -37,7 +43,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.now()
       ).execute()
@@ -54,7 +61,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()
@@ -71,7 +79,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.parse("1999-01-01T00:10:00.000")
       ).execute()
@@ -89,7 +98,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.parse("2002-01-01T00:10:00.000")
       ).execute()
@@ -107,7 +117,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()
@@ -124,7 +135,8 @@ abstract class FeedbooksRightsCheckContract {
         parameters = SingleLicenseCheckParameters(
           manifest = manifest,
           userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-          onStatusChanged = { }
+          onStatusChanged = { },
+          cacheDirectory = tempFolder.newFolder("cache")
         ),
         timeNow = LocalDateTime.parse("2000-01-01T00:10:00.000")
       ).execute()

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksSignatureCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/FeedbooksSignatureCheckContract.kt
@@ -1,0 +1,73 @@
+package org.librarysimplified.audiobook.tests
+
+import org.joda.time.LocalDateTime
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.librarysimplified.audiobook.api.PlayerUserAgent
+import org.librarysimplified.audiobook.feedbooks.FeedbooksRightsCheck
+import org.librarysimplified.audiobook.feedbooks.FeedbooksSignatureCheck
+import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
+import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckResult
+import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckStatus
+import org.librarysimplified.audiobook.manifest.api.PlayerManifest
+import org.librarysimplified.audiobook.manifest_parser.api.ManifestParsers
+import org.librarysimplified.audiobook.manifest_parser.extension_spi.ManifestParserExtensionType
+import org.librarysimplified.audiobook.parser.api.ParseResult
+import org.slf4j.Logger
+import java.net.URI
+import java.util.ServiceLoader
+
+abstract class FeedbooksSignatureCheckContract {
+
+  private lateinit var eventLog: MutableList<SingleLicenseCheckStatus>
+
+  abstract fun log(): Logger
+
+  @Before
+  fun testSetup() {
+    this.eventLog = mutableListOf()
+  }
+
+  @Test
+  fun testOK() {
+    val manifest = this.manifest("feedbooks_0.json")
+
+    val result =
+      FeedbooksSignatureCheck(
+        parameters = SingleLicenseCheckParameters(
+          manifest = manifest,
+          userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
+          onStatusChanged = { }
+        )
+      ).execute()
+
+    Assert.assertTrue(result is SingleLicenseCheckResult.Succeeded)
+  }
+
+  private fun manifest(
+    name: String
+  ): PlayerManifest {
+    val result =
+      ManifestParsers.parse(
+        uri = URI.create(name),
+        streams = this.resource(name),
+        extensions = ServiceLoader.load(ManifestParserExtensionType::class.java).toList()
+      )
+    this.log().debug("result: {}", result)
+    Assert.assertTrue("Result is success", result is ParseResult.Success)
+
+    val success: ParseResult.Success<PlayerManifest> =
+      result as ParseResult.Success<PlayerManifest>
+
+    return success.result
+  }
+
+  private fun resource(
+    name: String
+  ): ByteArray {
+    val path = "/org/librarysimplified/audiobook/tests/" + name
+    return FeedbooksSignatureCheckContract::class.java.getResourceAsStream(path)?.readBytes()
+      ?: throw AssertionError("Missing resource file: " + path)
+  }
+}

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseCheckContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/LicenseCheckContract.kt
@@ -2,7 +2,9 @@ package org.librarysimplified.audiobook.tests
 
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.license_check.api.LicenseCheckParameters
 import org.librarysimplified.audiobook.license_check.api.LicenseCheckProviderType
@@ -20,6 +22,7 @@ import java.io.IOException
 import java.net.URI
 import java.util.ServiceLoader
 
+
 abstract class LicenseCheckContract {
 
   private lateinit var eventLog: MutableList<SingleLicenseCheckStatus>
@@ -27,6 +30,10 @@ abstract class LicenseCheckContract {
   abstract fun log(): Logger
 
   abstract fun licenseChecks(): LicenseCheckProviderType
+
+  @Rule
+  @JvmField
+  val tempFolder = TemporaryFolder()
 
   @Before
   fun testSetup() {
@@ -46,7 +53,8 @@ abstract class LicenseCheckContract {
       LicenseCheckParameters(
         manifest = manifest,
         userAgent = PlayerUserAgent("org.librarysimplified.audiobook.tests 1.0.0"),
-        checks = listOf()
+        checks = listOf(),
+        cacheDirectory = tempFolder.newFolder("cache")
       )
 
     val result =
@@ -77,7 +85,8 @@ abstract class LicenseCheckContract {
           SucceedingTest(),
           FailingTest(),
           SucceedingTest()
-        )
+        ),
+        cacheDirectory = tempFolder.newFolder("cache")
       )
 
     val result =
@@ -108,7 +117,8 @@ abstract class LicenseCheckContract {
           SucceedingTest(),
           CrashingTest(),
           SucceedingTest()
-        )
+        ),
+        cacheDirectory = tempFolder.newFolder("cache")
       )
 
     val result =
@@ -139,7 +149,8 @@ abstract class LicenseCheckContract {
           NonApplicableTest(),
           NonApplicableTest(),
           NonApplicableTest()
-        )
+        ),
+        cacheDirectory = tempFolder.newFolder("cache")
       )
 
     val result =

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/feedbooks_2.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/feedbooks_2.json
@@ -1,0 +1,854 @@
+{
+  "@context": "http://readium.org/webpub/default.jsonld",
+  "metadata": {
+    "@type": "http://schema.org/book",
+    "title": "Rise of the Dragons, Book 1",
+    "author": "Angie Sage",
+    "identifier": "urn:uuid:35c5e499-9cb9-46e0-9e47-c517973f9e7f",
+    "language": "unknown",
+    "modified": "N/A",
+    "http://www.feedbooks.com/audiobooks/rights": {
+      "start": null,
+      "end": "2020-02-19T00:00:00Z"
+    },
+    "http://www.feedbooks.com/audiobooks/signature": {
+      "issuer": "https://www.cantookaudio.com",
+      "algorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
+      "value": "hEAVibxd0TnbFKnVj2X4ooH7PKPg9+5X1ODIp0BlpzVnF6SZtZcwB1Di4uX+JVgFNFFdn/s34ooemdJGGaLgZyqtr0kEwDAbBtegSQ09F/xJZ9UsnWpbjMlk0m4LBOmlhOKtmXnu/EJu9zLsLN8c/hHe8dbs2T0Ky5evbvsqVV3dkKTV60B7xGjlac3TrCkCnwq3pWdxDCnV75HUTxvhLDpL/REaIM+SG7lUE2WJabrn0qZ99YDonUm9T+LHnorV2v5EZ1bQu1IdQ9Nhv8nJ6IXOKzLP4N26Qu0047asGTHRBts5ydgKVMwuU+b6RgLs3aYMwsSh1k3PlRTZglgpyw=="
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "http://listen.cantookaudio.com/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4?sig=25Gx6ZBTmBS7pqoKSdD19ZLiKzDxYhy9Axq4n7KmG8k=",
+      "type": "application/audiobook+json"
+    },
+    {
+      "rel": "cover",
+      "href": "https://storage.googleapis.com/cantookhub-media-cant/f8/356d36b9a857a8fb1bcf61e58148943d761b6f.jpg",
+      "type": "image/jpeg"
+    }
+  ],
+  "spine": [
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a520974b-21a1-4746-87f0-1bce9d4bd194.mp4",
+      "type": "audio/mp4",
+      "title": "001_RiseOfTheDragons_Ch01",
+      "duration": 567,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a520974b-21a1-4746-87f0-1bce9d4bd194.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/56a1b5a9-3857-4372-9019-eb1217135fe2.mp4",
+      "type": "audio/mp4",
+      "title": "002_RiseOfTheDragons_Ch02",
+      "duration": 741,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/56a1b5a9-3857-4372-9019-eb1217135fe2.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/e9692c29-e1f0-4840-8efe-136ab6b0d20c.mp4",
+      "type": "audio/mp4",
+      "title": "003_RiseOfTheDragons_Ch03",
+      "duration": 756,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/e9692c29-e1f0-4840-8efe-136ab6b0d20c.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a789ba5c-ebf3-4618-b7a3-c374e1fab820.mp4",
+      "type": "audio/mp4",
+      "title": "004_RiseOfTheDragons_Ch04",
+      "duration": 202,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a789ba5c-ebf3-4618-b7a3-c374e1fab820.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f578714f-251e-4a04-a069-5a37f4170177.mp4",
+      "type": "audio/mp4",
+      "title": "005_RiseOfTheDragons_Ch05",
+      "duration": 695,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f578714f-251e-4a04-a069-5a37f4170177.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/2a8e62da-30d5-45b2-b890-c3821c6fbfbd.mp4",
+      "type": "audio/mp4",
+      "title": "006_RiseOfTheDragons_Ch06",
+      "duration": 879,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/2a8e62da-30d5-45b2-b890-c3821c6fbfbd.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/30842ad8-e1aa-4c70-9805-fb2f30b2e92f.mp4",
+      "type": "audio/mp4",
+      "title": "007_RiseOfTheDragons_Ch07",
+      "duration": 791,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/30842ad8-e1aa-4c70-9805-fb2f30b2e92f.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/fe44249e-bed4-463c-83ef-d8db923ded20.mp4",
+      "type": "audio/mp4",
+      "title": "008_RiseOfTheDragons_Ch08",
+      "duration": 1046,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/fe44249e-bed4-463c-83ef-d8db923ded20.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/491e9a56-5991-4885-83c8-585adf9b8fcd.mp4",
+      "type": "audio/mp4",
+      "title": "009_RiseOfTheDragons_Ch09",
+      "duration": 268,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/491e9a56-5991-4885-83c8-585adf9b8fcd.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/459a5ccc-98eb-4cfb-b3d7-028fe447e543.mp4",
+      "type": "audio/mp4",
+      "title": "010_RiseOfTheDragons_Ch10",
+      "duration": 228,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/459a5ccc-98eb-4cfb-b3d7-028fe447e543.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/533ff3cb-370f-427d-911d-fbd88a043c4c.mp4",
+      "type": "audio/mp4",
+      "title": "011_RiseOfTheDragons_Ch11",
+      "duration": 995,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/533ff3cb-370f-427d-911d-fbd88a043c4c.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/7068f71a-22ca-461b-9219-73212dbefbdc.mp4",
+      "type": "audio/mp4",
+      "title": "012_RiseOfTheDragons_Ch12",
+      "duration": 527,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/7068f71a-22ca-461b-9219-73212dbefbdc.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/b6aab012-cb6d-4ed8-af3e-2cb901cb23ae.mp4",
+      "type": "audio/mp4",
+      "title": "013_RiseOfTheDragons_Ch13",
+      "duration": 633,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/b6aab012-cb6d-4ed8-af3e-2cb901cb23ae.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/4a67b43c-93da-4a11-838b-16e39e441a88.mp4",
+      "type": "audio/mp4",
+      "title": "014_RiseOfTheDragons_Ch14",
+      "duration": 1025,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/4a67b43c-93da-4a11-838b-16e39e441a88.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/eb91bda1-ac89-4ea5-9fe2-ba0190d7e79d.mp4",
+      "type": "audio/mp4",
+      "title": "015_RiseOfTheDragons_Ch15",
+      "duration": 1091,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/eb91bda1-ac89-4ea5-9fe2-ba0190d7e79d.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d9a8221f-dc79-495f-81a3-3e0f61cc4cca.mp4",
+      "type": "audio/mp4",
+      "title": "016_RiseOfTheDragons_Ch16",
+      "duration": 806,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d9a8221f-dc79-495f-81a3-3e0f61cc4cca.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/27c387dd-ee30-4d42-bfe0-f6e7c8e15119.mp4",
+      "type": "audio/mp4",
+      "title": "017_RiseOfTheDragons_Ch17",
+      "duration": 690,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/27c387dd-ee30-4d42-bfe0-f6e7c8e15119.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/08c3d916-58e6-4952-a25b-7a7de7a0c1fc.mp4",
+      "type": "audio/mp4",
+      "title": "018_RiseOfTheDragons_Ch18",
+      "duration": 371,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/08c3d916-58e6-4952-a25b-7a7de7a0c1fc.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f0a55dc0-b9ef-4191-9b73-77810d90de41.mp4",
+      "type": "audio/mp4",
+      "title": "019_RiseOfTheDragons_Ch19",
+      "duration": 953,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f0a55dc0-b9ef-4191-9b73-77810d90de41.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d33c84e8-7f3a-43ec-a5b8-cda510eb7550.mp4",
+      "type": "audio/mp4",
+      "title": "020_RiseOfTheDragons_Ch20",
+      "duration": 317,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d33c84e8-7f3a-43ec-a5b8-cda510eb7550.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d3198438-a8c5-4651-b9ad-3ef5c2948b46.mp4",
+      "type": "audio/mp4",
+      "title": "021_RiseOfTheDragons_Ch21",
+      "duration": 453,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d3198438-a8c5-4651-b9ad-3ef5c2948b46.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/80405eb2-66f0-4b19-9506-403243d3809f.mp4",
+      "type": "audio/mp4",
+      "title": "022_RiseOfTheDragons_Ch22",
+      "duration": 704,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/80405eb2-66f0-4b19-9506-403243d3809f.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/ee4fe3ca-89e5-4659-b691-95bcc985f6f0.mp4",
+      "type": "audio/mp4",
+      "title": "023_RiseOfTheDragons_Ch23",
+      "duration": 792,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/ee4fe3ca-89e5-4659-b691-95bcc985f6f0.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/bea10189-918e-4b7f-a3d5-49298c43f215.mp4",
+      "type": "audio/mp4",
+      "title": "024_RiseOfTheDragons_Ch24",
+      "duration": 1252,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/bea10189-918e-4b7f-a3d5-49298c43f215.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/3d678379-22ac-46a5-aefd-2f546768576e.mp4",
+      "type": "audio/mp4",
+      "title": "025_RiseOfTheDragons_Ch25",
+      "duration": 775,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/3d678379-22ac-46a5-aefd-2f546768576e.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d1ef8023-daf3-4833-a240-70ffbc2dba1c.mp4",
+      "type": "audio/mp4",
+      "title": "026_RiseOfTheDragons_Ch26",
+      "duration": 1010,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d1ef8023-daf3-4833-a240-70ffbc2dba1c.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/1c0ba428-1f4a-41b0-ae78-7c9db5ea7b34.mp4",
+      "type": "audio/mp4",
+      "title": "027_RiseOfTheDragons_Ch27",
+      "duration": 844,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/1c0ba428-1f4a-41b0-ae78-7c9db5ea7b34.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/86cd4f75-1d5d-4c9b-8f89-c4b5d8e704ca.mp4",
+      "type": "audio/mp4",
+      "title": "028_RiseOfTheDragons_Ch28",
+      "duration": 807,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/86cd4f75-1d5d-4c9b-8f89-c4b5d8e704ca.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a8a19fa2-adce-474e-ae14-5e1dac614cd8.mp4",
+      "type": "audio/mp4",
+      "title": "029_RiseOfTheDragons_Ch29",
+      "duration": 834,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/a8a19fa2-adce-474e-ae14-5e1dac614cd8.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/c12ebf0b-4d91-479a-911a-31c7b6bb0f06.mp4",
+      "type": "audio/mp4",
+      "title": "030_RiseOfTheDragons_Ch30",
+      "duration": 412,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/c12ebf0b-4d91-479a-911a-31c7b6bb0f06.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/76779e6e-ec5d-4763-9b44-0fd8645551df.mp4",
+      "type": "audio/mp4",
+      "title": "031_RiseOfTheDragons_Ch31",
+      "duration": 614,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/76779e6e-ec5d-4763-9b44-0fd8645551df.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/bca01df9-bc9c-4d48-b027-e1baef84fbab.mp4",
+      "type": "audio/mp4",
+      "title": "032_RiseOfTheDragons_Ch32",
+      "duration": 757,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/bca01df9-bc9c-4d48-b027-e1baef84fbab.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d460fcb0-8258-41e6-9957-788b704338ed.mp4",
+      "type": "audio/mp4",
+      "title": "033_RiseOfTheDragons_Ch33",
+      "duration": 460,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/d460fcb0-8258-41e6-9957-788b704338ed.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/c9bc2902-932c-44fa-b928-5e7d2a1700f0.mp4",
+      "type": "audio/mp4",
+      "title": "034_RiseOfTheDragons_Ch34",
+      "duration": 388,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/c9bc2902-932c-44fa-b928-5e7d2a1700f0.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/cc24bfb1-5bd1-41ae-9f7a-e87dac6aa8a6.mp4",
+      "type": "audio/mp4",
+      "title": "035_RiseOfTheDragons_Ch35",
+      "duration": 351,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/cc24bfb1-5bd1-41ae-9f7a-e87dac6aa8a6.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/52bafeeb-afd0-4191-a962-5e26459f3630.mp4",
+      "type": "audio/mp4",
+      "title": "036_RiseOfTheDragons_Ch36",
+      "duration": 686,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/52bafeeb-afd0-4191-a962-5e26459f3630.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/b1bc9698-a41f-460e-9a71-bab1020c514a.mp4",
+      "type": "audio/mp4",
+      "title": "037_RiseOfTheDragons_Ch37",
+      "duration": 368,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/b1bc9698-a41f-460e-9a71-bab1020c514a.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/176f28cf-0d9a-408d-8542-3b9152969a4d.mp4",
+      "type": "audio/mp4",
+      "title": "038_RiseOfTheDragons_Ch38",
+      "duration": 1624,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/176f28cf-0d9a-408d-8542-3b9152969a4d.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f6723fd3-2c20-4d65-b844-9d7ba9217000.mp4",
+      "type": "audio/mp4",
+      "title": "039_RiseOfTheDragons_Ch39",
+      "duration": 292,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/f6723fd3-2c20-4d65-b844-9d7ba9217000.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/78d853f2-7a23-43a8-b1be-06960df07148.mp4",
+      "type": "audio/mp4",
+      "title": "040_RiseOfTheDragons_Ch40",
+      "duration": 1083,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/78d853f2-7a23-43a8-b1be-06960df07148.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    },
+    {
+      "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/239ebec6-1f8e-41d2-a84f-47c5b26d9373.mp4",
+      "type": "audio/mp4",
+      "title": "041_RiseOfTheDragons_Ch41",
+      "duration": 1078,
+      "bitrate": 64,
+      "alternates": [
+        {
+          "href": "https://listen.cantookaudio.com/item/f41c9234-e0a2-42fb-946d-8e92ec0f1ac4/239ebec6-1f8e-41d2-a84f-47c5b26d9373.ogg",
+          "type": "audio/ogg",
+          "bitrate": 32
+        }
+      ],
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    }
+  ]
+}

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/feedbooks_3.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/feedbooks_3.json
@@ -1,0 +1,59 @@
+{
+  "@context": "http://readium.org/webpub-manifest/context.jsonld",
+
+  "readingOrder": [
+    {
+      "duration": 128,
+      "title": "01 - Invocation",
+      "href": "http://archive.org/download/gleams_of_sunshine_1607_librivox/gleamsofsunshine_01_chant.mp3",
+      "bitrate": "120",
+      "type": "audio/mpeg",
+      "properties": {
+        "encrypted": {
+          "scheme": "http://www.feedbooks.com/audiobooks/access-restriction",
+          "profile": "https://www.cantookaudio.com"
+        }
+      }
+    }
+  ],
+
+  "links": [
+    {
+      "href": "http://archive.org/services/img/gleams_of_sunshine_1607_librivox",
+      "rel": "cover",
+      "width": 180,
+      "height": 180,
+      "type": "image/jpeg"
+    },
+    {
+      "rel": "self",
+      "href": "https://api.archivelab.org/books/gleams_of_sunshine_1607_librivox/opds_audio_manifest",
+      "type": "application/audiobook+json"
+    },
+    {
+      "href": "http://example.com/license/status",
+      "type": "application/vnd.readium.license.status.v1.0+json",
+      "rel": "license"
+    }
+  ],
+
+  "metadata": {
+    "identifier": "http://archive.org/details/gleams_of_sunshine_1607_librivox",
+    "@type": "https://schema.org/Audiobook",
+    "author": "Joseph Horatio Chant",
+    "tracks": 172,
+    "duration": 22173,
+    "title": "Gleams of Sunshine",
+    "language": "en",
+
+    "http://www.feedbooks.com/audiobooks/signature": {
+      "algorithm": "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+      "issuer": "https://www.cantookaudio.com",
+      "value": "eKLux/4TtJc6VH6RTOi5lBMh9mT1j2y1z50OruWZgy8QjyPMjDV+aVZWUt7OUTinUHQfWNPBB6DxixgTZ07TQsix4uScL2dJZRQTjUKKHv3he7oJdOkcxjWDh51Q6U2KbDfC2MReG/+Qa4meoI5BN0Q8FKIEFMDZJ2KQTSRj13ZETaD0Nwz+8d6IN7csQGFJHvW/bBJthty+eZNzIr+VE0Kf02OS4yX+wvsExfRabvHlfimT1uUTWc89CgPAuM+Y7vdtjb+B3YFr7ibXATk6lQJkXzKol9ms6vkNwnvxzXwsQ+p1ZjejH1LOYADvedl/ItPrBGkhmq7bbUz91jUd+w=="
+    },
+    "http://www.feedbooks.com/audiobooks/rights": {
+      "start": "2020-02-01T17:15:52Z",
+      "end": "2020-03-29T17:15:52Z"
+    }
+  }
+}

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_0.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_0.json
@@ -1,0 +1,11 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "e": "AQAB",
+      "kid": "d82fcf13-96ba-47a3-b9bf-332b5d9dac89",
+      "n": "7GcBZtUVccXneZdDu5KjhxUOo6cxqM718Uaiw6kZns-AGz_2B0MUs8rvh4EEkHK-w3BZu6ZjARAJlkQPy13dARZ35IXKpw7NSftVUPpsGxFJLbgZ3QLFAPsmecodLTW4S_zqzkbbw4iOGTj2hhMtqoGBss-MHu2Ng04cVfkQAe4rhCZou3sSTljxj18rCyR840Y6TB9g9j2MFk9QbM3e-N_LdQrOeRgvuU_3HhPXgVb7T2qMksWqaV_kEC3_FammKJNbZ0MxaDX5dNuUeJXCVVcYPrpKdrRlJjDCbcEyo2bZHmpmO0-hP0xbcig-EMP5NGBBmvejOl5UhwdW0UEWcw",
+      "http://www.feedbooks.com/audiobooks/signature/pem-key": "-----BEGIN PUBLIC KEY-----\n MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA7GcBZtUVccXneZdDu5Kj\nhxUOo6cxqM718Uaiw6kZns+AGz/2B0MUs8rvh4EEkHK+w3BZu6ZjARAJlkQPy13d\nARZ35IXKpw7NSftVUPpsGxFJLbgZ3QLFAPsmecodLTW4S/zqzkbbw4iOGTj2hhMt\nqoGBss+MHu2Ng04cVfkQAe4rhCZou3sSTljxj18rCyR840Y6TB9g9j2MFk9QbM3e\n+N/LdQrOeRgvuU/3HhPXgVb7T2qMksWqaV/kEC3/FammKJNbZ0MxaDX5dNuUeJXC\nVVcYPrpKdrRlJjDCbcEyo2bZHmpmO0+hP0xbcig+EMP5NGBBmvejOl5UhwdW0UEW\ncwIDAQAB\n-----END PUBLIC KEY-----"
+    }
+  ]
+}

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_1.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_1.json
@@ -1,0 +1,17 @@
+{
+  "keys": [
+    {
+      "p": "1QDDWz66-Dz5j3CCsecDK8389L94Y5OWgNvFf5Z4Q5qhpHdDjDPdL3Fbxovs_iRCK8LFayLSKPo5YmHdq-0Vv9j5o_d9-gRILjmMUva0Y4Iaj0EqQbizdDV4rzx7dNoiuvo56ROALTUsycFhDRfjhB1fd6VNOxRLrS4bFBBxDOE",
+      "kty": "RSA",
+      "q": "r04ty61JPbDggRNhZI0snt8i9Nj-BNN-QAX9VIWR03S82OUSJvpsWgNt--AoHRgG1oZDlCW4lmRYeT1C7d5OwjMdK2_yQFSlm4aslf2zha1m44jzRDGSQlc7toDMyTwQEPzMHT4MV5i0F6SdYvbmIipq9qgeDkmMja9Ud_O8jTE",
+      "d": "BNaqSC6zM_1NyO0SUPEmL54REFtxSh-6LHqP2bn89kL-ac1NhOaRDIWBtbwh7f4wXFGK-FDqYnWYENxtQT6HHacWrwcW5LPaDkv68jdyfJvSuzvtFvRYrnS1DD8jTyIAC49d4UNyyvSiAGLR_1jaEClnBlQ9BbY5TvAK6okBaQjRYVYaG-LIEsbdBP1pTkijw7APfcmPBlspJMlupMi3tzOZmtf-Pxnxz_SmwilF5fctGD6E41xRYe54D0mEEQ70FRe5JPB_OF3B1lMrG4sQDU-fteG-F803mUBrNwoqv9me-MGPsidRYoHJmOhRami4sG4cdTy77dq5uSkl66BsAQ",
+      "e": "AQAB",
+      "use": "sig",
+      "qi": "Id7YiuTCa5URck_fLKygTpiG9HNrT9Eb9neRHay2AfQc_YlRueeMNlLTPW9zvNrcyBI8FgfJrCZGk_3nT3paXJEfU4Gim-AwkVN-jdrWyDKyc7rMgwQjdT1hpG6V2QwQbLbFYorSviID1guujoa6kqXeAQ2MPhTGJkBvY33AWmM",
+      "dp": "QzZibsB0rzBOb3zJQOnsjj4JvBFPI9zGeRLgV0pb2LlKmGMp5WvYN8hFdXlh5y_50WU8dnoeZt_Oi8Tl9gJyAn-tBphqICKJxExUgzll4qCDUQD3HJXzyo-07Vbgfhb3LpkW_P0yTRGieGeVAFSxblb2cQKwRBw7ZQJPeR1XDwE",
+      "alg": "RS256",
+      "dq": "gmTJRYV4Q-3Ln9a1i6BCf02D59F7aEWT07Vg0Dyl0j4ztbT1go6kh3OjnEUIMVPMykaF_6zrFto-wLdjkCDaPjLc0JFtBJKxt_Q9bTePD7CCJl6Ya7Hfk37lSIOXT1tgq_INNPcRIRrRYgCsnI7_cIxSkXNNH91vMXgngS2HoxE",
+      "n": "kdyR4X_PVJulWwIHxgBeS2Skq_t709f_jaDkeq6YK1QoIWi45lblwD33bqviGty3DS1eqJyycYN6DE33t-h9yK3YrvUoP3Cp0hRmeGRpC1dL9Xq9N_wwX8fj2d6BU8KroqsmdmH6oX4cYZkghSnZ93VsiewkBvn_MdoQyg8Q9iQviu-sdHtfzEi7AfCaxl-bJEW7pzAV9sOtzKIGiMUk8hXP13WfSpIuiZFSLelO9Uma0_DfeauSLkXJdWRaCexL4p3JH5C_Rujdx2fx_OeCjAXs9hdlmLRVGnvuCUeC25mTfJ7snURl7oRWSyK-kYMgLM0gRY1WY5Lwqm67cfdkEQ"
+    }
+  ]
+}

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_2.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/jwks_2.json
@@ -1,0 +1,1 @@
+oops this is not really a certificate

--- a/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/FeedbooksSignatureCheckTest.kt
+++ b/org.librarysimplified.audiobook.tests/src/test/java/org/librarysimplified/audiobook/tests/local/FeedbooksSignatureCheckTest.kt
@@ -1,0 +1,11 @@
+package org.librarysimplified.audiobook.tests.local
+
+import org.librarysimplified.audiobook.tests.FeedbooksSignatureCheckContract
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class FeedbooksSignatureCheckTest : FeedbooksSignatureCheckContract() {
+  override fun log(): Logger {
+    return LoggerFactory.getLogger(FeedbooksSignatureCheckTest::class.java)
+  }
+}


### PR DESCRIPTION
**What's this do?**

Verify the signature on a Feedbooks audio book.

Implementation notes:
- The check is done by verifying the public key, not by signing with the private key and comparing the result.
- Feedbooks is now providing a cache-control header when the certificate is downloaded. Caching is handled by the http client, because it already knows how to deal with this.
- In order to support caching, the `LicenseCheckParameters` class now has a non-nullable `cacheDirectory` constructor arg. This is a semver major change.
- After a new version of audiobook-android is published with this change, I will make a pull request on Simplified-Android-Core to use the new version, and to pass in the `cacheDirectory` parameter.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2507](https://jira.nypl.org/browse/SIMPLY-2507).

**How should this be tested? / Do these changes have associated tests?**

Attempting to read an audiobook whose manifest contains an invalid signature should fail. Unit tests are included.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this in the vanilla app.