### PR TITLE
SIMPLY-2947: Prevent repeated seeks when opening a spine item.

### DIFF
--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -353,11 +353,11 @@ class ExoAudioBookPlayer private constructor(
       )
 
     this.exoPlayer.prepare(this.exoAudioRenderer)
-    this.exoPlayer.playWhenReady = true
     this.seek(offset)
+    this.exoPlayer.playWhenReady = true
 
     this.setPlayerPlaybackRate(this.currentPlaybackRate)
-    return this.schedulePlaybackObserverForSpineElement(spineElement, initialSeek = offset)
+    return this.schedulePlaybackObserverForSpineElement(spineElement, initialSeek = null)
   }
 
   /**


### PR DESCRIPTION
**What's this do?**

Remove a redundant seek when opening a spine item, and perform the initial seek before playback starts.

Currently, in `openSpineElement`:

- The player is started, then a seek is issued to the initial offset. https://github.com/NYPL-Simplified/audiobook-android/blob/75a68d2498a702afa8f94179e82314c151e17a14/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt#L356-L357
This first seek happens after playback starts, but it's fast enough that the seek is inaudible. Still, it should be done before starting playback, to prevent doing extra work.

- A playback observer is scheduled, with `initialSeek` set to the initial offset: https://github.com/NYPL-Simplified/audiobook-android/blob/75a68d2498a702afa8f94179e82314c151e17a14/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt#L360
This causes the playback observer to issue a seek to that offset when it first runs. Since it is scheduled to run once a second, the player returns to the initial position after one second has played.

**Why are we doing this? (w/ JIRA link if applicable)**

This fixes [SIMPLY-2947](https://jira.nypl.org/browse/SIMPLY-2947).

**How should this be tested? / Do these changes have associated tests?**

Play an audiobook. The first second of audio should not be repeated. Navigate to a different spine item from the TOC. The first second of audio should not be repeated.

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this in the SimplyE app with audiobooks from various distributors. 