### PR TITLE
SIMPLY-3282: Tweak some string resources in player and TOC.

### DIFF
--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -721,8 +721,14 @@ class PlayerFragment : Fragment() {
   }
 
   private fun spineElementText(spineElement: PlayerSpineElementType): String {
+    val title = spineElement.title ?: this.getString(
+      R.string.audiobook_player_toc_chapter_n,
+      spineElement.index + 1
+    )
+
     return this.getString(
       R.string.audiobook_player_spine_element,
+      title,
       spineElement.index + 1,
       spineElement.book.spine.size
     )
@@ -735,9 +741,16 @@ class PlayerFragment : Fragment() {
 
   private fun configureSpineElementText(element: PlayerSpineElementType) {
     this.playerSpineElement.text = this.spineElementText(element)
+
+    val accessibilityTitle = element.title ?: this.getString(
+      R.string.audiobook_accessibility_toc_chapter_n,
+      element.index + 1
+    )
+
     this.playerSpineElement.contentDescription =
       this.getString(
         R.string.audiobook_accessibility_chapter_of,
+        accessibilityTitle,
         element.index + 1,
         this.book.spine.size
       )

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -20,9 +20,9 @@
   <string name="audiobook_player_toc_title">Table Of Contents</string>
   <string name="audiobook_player_title">Audio Book Player</string>
 
-  <string name="audiobook_player_spine_element">Chapter %1$d of %2$d</string>
+  <string name="audiobook_player_spine_element">%1$s (file %2$d of %3$d)</string>
 
-  <string name="audiobook_player_sleep_end_of_chapter">End of chapter</string>
+  <string name="audiobook_player_sleep_end_of_chapter">End of file</string>
   <string name="audiobook_player_sleep_60">60:00</string>
   <string name="audiobook_player_sleep_45">45:00</string>
   <string name="audiobook_player_sleep_30">30:00</string>
@@ -31,7 +31,7 @@
   <string name="audiobook_player_sleep_off">Off</string>
 
   <string name="audiobook_player_buffering">Buffering…</string>
-  <string name="audiobook_player_waiting">Chapter %1$d must be downloaded to continue playback.</string>
+  <string name="audiobook_player_waiting">File %1$d must be downloaded to continue playback.</string>
   <string name="audiobook_player_error">An error occurred during playback. Error code: %1$d</string>
 
   <string name="audiobook_player_toc_chapter_n">Chapter %1$d</string>
@@ -59,7 +59,7 @@
 
   <string name="audiobook_accessibility_menu_sleep_timer_icon">Set Your Sleep Timer</string>
   <string name="audiobook_accessibility_menu_sleep_timer">Sleep Timer Menu</string>
-  <string name="audiobook_accessibility_menu_sleep_timer_item_at_end_of_chapter">Sleep At End of Chapter</string>
+  <string name="audiobook_accessibility_menu_sleep_timer_item_at_end_of_chapter">Sleep At End of File</string>
   <string name="audiobook_accessibility_menu_sleep_timer_item_in_60_minutes">Sleep In 60 Minutes</string>
   <string name="audiobook_accessibility_menu_sleep_timer_item_in_45_minutes">Sleep In 45 Minutes</string>
   <string name="audiobook_accessibility_menu_sleep_timer_item_in_30_minutes">Sleep In 30 Minutes</string>
@@ -67,7 +67,7 @@
   <string name="audiobook_accessibility_menu_sleep_timer_item_off">Sleep Timer Off</string>
   <string name="audiobook_accessibility_menu_sleep_timer_item_now">Sleep Now</string>
 
-  <string name="audiobook_accessibility_sleep_timer_description_end_of_chapter">Sleep At End of Chapter</string>
+  <string name="audiobook_accessibility_sleep_timer_description_end_of_chapter">Sleep At End of File</string>
   <string name="audiobook_accessibility_sleep_timer_description_60_minutes">Sleep In 60 Minutes</string>
   <string name="audiobook_accessibility_sleep_timer_description_45_minutes">Sleep In 45 Minutes</string>
   <string name="audiobook_accessibility_sleep_timer_description_30_minutes">Sleep In 30 Minutes</string>
@@ -79,7 +79,7 @@
   <string name="audiobook_accessibility_sleep_timer_label">Sleep Timer</string>
   <string name="audiobook_accessibility_sleep_timer_is_paused">The Sleep Timer Is Paused Because Playback Is Paused.</string>
 
-  <string name="audiobook_accessibility_chapter_of">Chapter %1$d of %2$d</string>
+  <string name="audiobook_accessibility_chapter_of">%1$s (file %2$d of %3$d)</string>
 
   <string name="audiobook_accessibility_menu_playback_speed_icon">Set Your Playback Speed</string>
   <string name="audiobook_accessibility_menu_playback_speed_0p75">75 percent</string>
@@ -100,18 +100,18 @@
 
   <string name="audiobook_accessibility_toc_chapter_n">Chapter %1$d</string>
   <string name="audiobook_accessibility_toc_chapter_is_current">Selected</string>
-  <string name="audiobook_accessibility_toc_chapter_requires_download">Chapter Must Be Downloaded Before It Can Be Played</string>
-  <string name="audiobook_accessibility_toc_chapter_failed_download">Chapter Has Failed To Download</string>
-  <string name="audiobook_accessibility_toc_chapter_downloading">Chapter Is Currently Downloading</string>
+  <string name="audiobook_accessibility_toc_chapter_requires_download">File Must Be Downloaded Before It Can Be Played</string>
+  <string name="audiobook_accessibility_toc_chapter_failed_download">File Has Failed To Download</string>
+  <string name="audiobook_accessibility_toc_chapter_downloading">File Is Currently Downloading</string>
   <string name="audiobook_accessibility_toc_chapter_duration_is">Duration</string>
 
-  <string name="audiobook_accessibility_toc_refresh_all">Download All Chapters</string>
-  <string name="audiobook_accessibility_toc_stop_all">Stop All Chapter Downloads</string>
-  <string name="audiobook_accessibility_toc_download">Download Chapter %1$d</string>
-  <string name="audiobook_accessibility_toc_cancel">Cancel Download Of Chapter %1$d</string>
-  <string name="audiobook_accessibility_toc_retry">Retry Download Of Chapter %1$d</string>
-  <string name="audiobook_accessibility_toc_progress">Download Progress Of Chapter %1$d is
+  <string name="audiobook_accessibility_toc_refresh_all">Download All Files</string>
+  <string name="audiobook_accessibility_toc_stop_all">Stop All File Downloads</string>
+  <string name="audiobook_accessibility_toc_download">Download File %1$d</string>
+  <string name="audiobook_accessibility_toc_cancel">Cancel Download Of File %1$d</string>
+  <string name="audiobook_accessibility_toc_retry">Retry Download Of File %1$d</string>
+  <string name="audiobook_accessibility_toc_progress">Download Progress Of File %1$d is
     %2$d Percent. Click To Stop Download.</string>
-  <string name="audiobook_accessibility_toc_selected">Selected Chapter %1$d</string>
+  <string name="audiobook_accessibility_toc_selected">Selected File %1$d</string>
 
 </resources>


### PR DESCRIPTION
**What's this do?**

- Refer to spine items generically as "files" instead of "chapters"
- Display the current spine item's title in the player, in addition to its file number

**Why are we doing this? (w/ JIRA link if applicable)**

See [SIMPLY-3282](https://jira.nypl.org/browse/SIMPLY-3282).

The UI currently refers to spine items generically as "chapters", e.g. "Chapter 1 of 10", or "Chapter 1 must be downloaded to continue playback". In this case "Chapter 1" refers to the first spine item (file). But in the TOC, the first spine item might be titled "Introduction", while the _second_ item is titled "Chapter 1". This can be confusing to end users. To mitigate this, this PR changes the term for a generic spine item to "file", and in addition displays the title from the TOC in the player. (If a title is not supplied for a spine item, the title continues to be displayed as "Chapter _n_".

**How should this be tested? / Do these changes have associated tests?**

Play an audiobook. The player should show the title of the currently playing file, which should be identical to the title displayed in the TOC for that file. "(file _n_ of _x_)" should appear after the title.

Any text that refers generically to a spine item (file) should now use the term "file" instead of "chapter". 

**Dependencies for merging? Releasing to production?**

n/a

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee played some books in the SimplyE app.