### PR TITLE
SMA-201: Long chapter title text is overlapping for audio books

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ ext.libraries = [
   androidXTestOrchestrator: "androidx.test:orchestrator:1.1.0",
   androidXTestRules       : "androidx.test:rules:1.1.0",
   androidXTestRunner      : "androidx.test:runner:1.1.0",
+  constraintLayout        : "androidx.constraintlayout:constraintlayout:2.0.4",
   googleExoplayer         : "com.google.android.exoplayer:exoplayer:r1.5.15",
   googleGuava             : "com.google.guava:guava:27.1-android",
   irradiaFieldrushAPI     : "one.irradia.fieldrush:one.irradia.fieldrush.api:${irradiaFieldrushVersion}",

--- a/org.librarysimplified.audiobook.views/build.gradle
+++ b/org.librarysimplified.audiobook.views/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 
   implementation libraries.androidXAppCompat
   implementation libraries.androidXRecyclerView
+  implementation libraries.constraintLayout
   implementation libraries.kotlinStdlib
   implementation libraries.kotlinReflect
   implementation libraries.slf4j

--- a/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/layout/player_view.xml
@@ -1,177 +1,199 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  android:id="@+id/player_view"
-  android:background="@color/audiobook_player_background_color"
-  android:padding="16dp"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent">
-
-  <TextView
-    android:id="@+id/player_title"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentTop="true"
-    android:layout_centerHorizontal="true"
-    android:gravity="center"
-    android:lines="1"
-    android:ellipsize="end"
-    android:text="Very, very, very long placeholder text that should never be seen in practice."
-    android:textColor="@color/audiobook_player_text_color"
-    android:textSize="24sp"
-    android:textStyle="bold" />
-
-  <TextView
-    android:id="@+id/player_author"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_below="@+id/player_title"
-    android:layout_centerHorizontal="true"
-    android:layout_marginTop="8dp"
-    android:gravity="center"
-    android:lines="1"
-    android:ellipsize="end"
-    android:text="Very, very, very long placeholder text that should never be seen in practice."
-    android:textColor="@color/audiobook_player_text_color"
-    android:textSize="18sp" />
-
-  <SeekBar
-    android:id="@+id/player_progress"
-    style="?android:attr/progressBarStyleHorizontal"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_below="@id/player_author"
-    android:layout_marginTop="16dp"
-    android:progress="0"
-    android:scaleY="2" />
-
-  <TextView
-    android:id="@+id/player_time"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentLeft="true"
-    android:layout_below="@+id/player_progress"
-    android:layout_marginTop="8dp"
-    android:text="00:00:00"
-    android:textColor="@color/audiobook_player_text_color"
-    android:textSize="16sp" />
-
-  <TextView
-    android:id="@+id/player_time_maximum"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentRight="true"
-    android:layout_below="@+id/player_progress"
-    android:layout_marginTop="8dp"
-    android:text="00:00:00"
-    android:textColor="@color/audiobook_player_text_color"
-    android:textSize="16sp" />
-
-  <TextView
-    android:id="@+id/player_spine_element"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_below="@+id/player_progress"
-    android:layout_centerHorizontal="true"
-    android:layout_marginTop="8dp"
-    android:gravity="center"
-    android:text="Chapter 0 of 0"
-    android:textSize="16sp"
-    android:textColor="@color/audiobook_player_text_color"
-    android:textStyle="bold" />
-
-  <ImageView
-    android:id="@+id/player_play_button"
-    android:layout_width="64dp"
-    android:layout_height="64dp"
-    android:layout_alignParentBottom="true"
-    android:layout_centerHorizontal="true"
-    android:contentDescription="@string/audiobook_accessibility_play"
-    android:src="@drawable/play_icon" />
-
-  <RelativeLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
-    android:layout_marginRight="32dp"
-    android:layout_toLeftOf="@+id/player_play_button">
-
-    <ImageView
-      android:id="@+id/player_jump_backwards"
-      android:layout_width="64dp"
-      android:layout_height="64dp"
-      android:contentDescription="@string/audiobook_accessibility_backward_15"
-      android:src="@drawable/circle_arrow_backward" />
-
-    <TextView
-      android:id="@+id/player_jump_forwards_text"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
-      android:layout_centerVertical="true"
-      android:paddingTop="4dp"
-      android:gravity="center"
-      android:clickable="false"
-      android:focusable="false"
-      android:importantForAccessibility="no"
-      android:text="15"
-      android:textColor="@color/audiobook_player_text_color"
-      android:textSize="18sp"
-      android:textStyle="bold" />
-  </RelativeLayout>
-
-  <RelativeLayout
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
-    android:layout_marginLeft="32dp"
-    android:layout_toRightOf="@+id/player_play_button">
-
-    <ImageView
-      android:id="@+id/player_jump_forwards"
-      android:layout_width="64dp"
-      android:layout_height="64dp"
-      android:contentDescription="@string/audiobook_accessibility_forward_15"
-      android:src="@drawable/circle_arrow_forward" />
-
-    <TextView
-      android:id="@+id/player_jump_backwards_text"
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_centerHorizontal="true"
-      android:layout_centerVertical="true"
-      android:paddingTop="4dp"
-      android:gravity="center"
-      android:clickable="false"
-      android:focusable="false"
-      android:importantForAccessibility="no"
-      android:text="15"
-      android:textColor="@color/audiobook_player_text_color"
-      android:textSize="18sp"
-      android:textStyle="bold" />
-  </RelativeLayout>
-
-  <TextView
-    android:id="@+id/player_waiting_buffering"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_centerHorizontal="true"
-    android:layout_above="@id/player_play_button"
-    android:layout_marginBottom="16dp"
-    android:gravity="center"
-    android:text="@string/audiobook_player_waiting"
-    android:textColor="@color/audiobook_player_text_color"
-    android:textStyle="bold"
-    android:textSize="14sp" />
-
-  <ImageView
-    android:id="@+id/player_cover"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/player_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_below="@id/player_spine_element"
-    android:layout_above="@id/player_waiting_buffering"
-    android:layout_marginTop="32dp"
-    android:layout_marginBottom="16dp"
-    android:src="@drawable/icon" />
+    android:background="@color/audiobook_player_background_color"
+    android:padding="16dp">
 
-</RelativeLayout>
+    <TextView
+        android:id="@+id/player_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:lines="1"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Very, very, very long placeholder text that should never be seen in practice." />
+
+    <TextView
+        android:id="@+id/player_author"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/player_title"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="8dp"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:lines="1"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="18sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_title"
+        tools:text="Very, very, very long placeholder text that should never be seen in practice." />
+
+    <SeekBar
+        android:id="@+id/player_progress"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:progress="0"
+        android:scaleY="2"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_author" />
+
+    <TextView
+        android:id="@+id/player_time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/player_progress"
+        android:layout_alignParentLeft="true"
+        android:layout_marginTop="8dp"
+        android:text="@string/audiobook_player_initial"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="16sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_progress" />
+
+    <TextView
+        android:id="@+id/player_time_maximum"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/player_progress"
+        android:layout_alignParentRight="true"
+        android:layout_marginTop="8dp"
+        android:text="@string/audiobook_player_initial"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_progress" />
+
+    <TextView
+        android:id="@+id/player_spine_element"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/player_progress"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="8dp"
+        android:gravity="center"
+        tools:text="Very, very, very long placeholder text that should never be seen in practice."
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_time" />
+
+    <ImageView
+        android:id="@+id/player_play_button"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:contentDescription="@string/audiobook_accessibility_play"
+        android:src="@drawable/play_icon"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/player_jump_backwards"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_marginEnd="32dp"
+        android:contentDescription="@string/audiobook_accessibility_backward_15"
+        android:src="@drawable/circle_arrow_backward"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/player_play_button"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <TextView
+        android:id="@+id/player_jump_forwards_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:clickable="false"
+        android:focusable="false"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:text="@string/audiobook_player_seek_15"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/player_jump_forwards"
+        app:layout_constraintEnd_toEndOf="@id/player_jump_forwards"
+        app:layout_constraintStart_toStartOf="@id/player_jump_forwards"
+        app:layout_constraintTop_toTopOf="@id/player_jump_forwards" />
+
+    <ImageView
+        android:id="@+id/player_jump_forwards"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_marginStart="32dp"
+        android:contentDescription="@string/audiobook_accessibility_forward_15"
+        android:src="@drawable/circle_arrow_forward"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/player_play_button" />
+
+    <TextView
+        android:id="@+id/player_jump_backwards_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true"
+        android:clickable="false"
+        android:focusable="false"
+        android:gravity="center"
+        android:importantForAccessibility="no"
+        android:text="@string/audiobook_player_seek_15"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toBottomOf="@id/player_jump_backwards"
+        app:layout_constraintEnd_toEndOf="@id/player_jump_backwards"
+        app:layout_constraintStart_toStartOf="@id/player_jump_backwards"
+        app:layout_constraintTop_toTopOf="@id/player_jump_backwards" />
+
+    <TextView
+        android:id="@+id/player_waiting_buffering"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="16dp"
+        android:gravity="center"
+        android:text="@string/audiobook_player_waiting"
+        android:textColor="@color/audiobook_player_text_color"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@id/player_play_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ImageView
+        android:id="@+id/player_cover"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
+        android:contentDescription="@string/audiobook_accessibility_book_cover"
+        android:src="@drawable/icon"
+        app:layout_constraintBottom_toTopOf="@id/player_waiting_buffering"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/player_time" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
+++ b/org.librarysimplified.audiobook.views/src/main/res/values/strings.xml
@@ -25,10 +25,12 @@
   <string name="audiobook_player_sleep_end_of_chapter">End of file</string>
   <string name="audiobook_player_sleep_60">60:00</string>
   <string name="audiobook_player_sleep_45">45:00</string>
+  <string name="audiobook_player_initial">00:00:00</string>
   <string name="audiobook_player_sleep_30">30:00</string>
   <string name="audiobook_player_sleep_15">15:00</string>
   <string name="audiobook_player_sleep_now">Now</string>
   <string name="audiobook_player_sleep_off">Off</string>
+  <string name="audiobook_player_seek_15">15</string>
 
   <string name="audiobook_player_buffering">Buffering…</string>
   <string name="audiobook_player_waiting">File %1$d must be downloaded to continue playback.</string>
@@ -40,6 +42,7 @@
   <string name="audiobook_player_toc_menu_stop_all_confirm">Stop all downloads?</string>
   <string name="audiobook_player_toc_menu_stop_confirm_positive">Stop</string>
   <string name="audiobook_player_toc_menu_stop_confirm_negative">Continue</string>
+
 
   <!--
     Accessibility strings.
@@ -97,6 +100,7 @@
   <string name="audiobook_accessibility_backward_15">Rewind 15 seconds</string>
   <string name="audiobook_accessibility_play">Play</string>
   <string name="audiobook_accessibility_pause">Pause</string>
+  <string name="audiobook_accessibility_book_cover">Book cover</string>
 
   <string name="audiobook_accessibility_toc_chapter_n">Chapter %1$d</string>
   <string name="audiobook_accessibility_toc_chapter_is_current">Selected</string>


### PR DESCRIPTION
**What's this do?**
1. Rewrote `player_view.xml` using `ConstraintLayout` to reduce the computation power it takes to render the view. The requires a new AndroidX `constraintlayout` dependency in `build.gradle`.
2. Moved chapter title text to new line.
3. Moved hard-coded strings to `strings.xml`
4. Moved placeholder text to `xmlns:tools`
5. Added accessibility attribute to book cover widget

**Why are we doing this? (w/ JIRA link if applicable)**
[SMA-201: Long chapter title text is overlapping for audio books](https://jira.nypl.org/browse/SMA-201)

**How should this be tested? / Do these changes have associated tests?**
Verify that long chapter title text is not overlapping for audio books. A good book to test is The Institute by Stephen King.

**Dependencies for merging? Releasing to production?**
n/a

**Screenshots**
<img width="411" alt="Screen Shot 2021-07-01 at 5 27 34 PM" src="https://user-images.githubusercontent.com/15109016/124197468-6da47f00-da83-11eb-90d6-8bce9c1b2397.png">
<img width="640" alt="Screen Shot 2021-07-01 at 5 30 55 PM" src="https://user-images.githubusercontent.com/15109016/124197475-72693300-da83-11eb-945a-1cf26d089261.png">

**Has the application documentation been updated for these changes?**
No documentation changes needed

**Did someone actually run this code to verify it works?**
n/a

**Notes**
I did exploring using Android's [Autosizing TextViews](https://developer.android.com/guide/topics/ui/look-and-feel/autosizing-textview) but our api level was too low at 21.