### PR TITLE
Accept null titles when parsing manifests

### DIFF
--- a/org.librarysimplified.audiobook.manifest_parser.webpub/src/main/java/org/librarysimplified/audiobook/manifest_parser/webpub/WebPubLinkParser.kt
+++ b/org.librarysimplified.audiobook.manifest_parser.webpub/src/main/java/org/librarysimplified/audiobook/manifest_parser/webpub/WebPubLinkParser.kt
@@ -90,7 +90,9 @@ class WebPubLinkParser(
       FRParserObjectFieldSchema(
         name = "title",
         parser = {
-          FRValueParsers.forString { title -> this.title = title }
+          FRValueParsers.acceptingNull(
+            FRValueParsers.forString { title -> this.title = title }
+          )
         },
         isOptional = true
       )

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerManifestContract.kt
@@ -104,6 +104,34 @@ abstract class PlayerManifestContract {
   }
 
   @Test
+  fun testOkNullTitles() {
+    val result =
+      ManifestParsers.parse(
+        uri = URI.create("nulltitles"),
+        streams = this.resource("null_titles.json"),
+        extensions = listOf()
+      )
+    this.log().debug("result: {}", result)
+    assertTrue("Result is success", result is ParseResult.Success)
+
+    val success: ParseResult.Success<PlayerManifest> =
+      result as ParseResult.Success<PlayerManifest>
+
+    val manifest = success.result
+    this.checkNullTitleValues(manifest)
+  }
+
+  private fun checkNullTitleValues(manifest: PlayerManifest) {
+    Assert.assertEquals(2, manifest.readingOrder.size)
+
+    // null title should be null
+    Assert.assertNull(manifest.readingOrder[0].title)
+
+    // no title should be null
+    Assert.assertNull(manifest.readingOrder[1].title)
+  }
+
+  @Test
   fun testOkFlatlandGardeur() {
     val result =
       ManifestParsers.parse(

--- a/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/null_titles.json
+++ b/org.librarysimplified.audiobook.tests/src/main/resources/org/librarysimplified/audiobook/tests/null_titles.json
@@ -1,0 +1,46 @@
+{
+  "@context": [
+    "http://readium.org/webpub/default.jsonld"
+  ],
+
+  "links": [
+    {
+      "href": "http://example.org/a",
+      "rel": "something-0"
+    },
+    {
+      "href": "http://example.org/b",
+      "rel": "something-1"
+    },
+    {
+      "href": "http://example.org/c",
+      "rel": "something-2"
+    }
+  ],
+
+  "readingOrder": [
+    {
+      "title": null,
+      "href": "http://www.example.com/0.mp3",
+      "duration": 100.0,
+      "type": "audio/mpeg"
+    },
+    {
+      "href": "http://www.example.com/1.mp3",
+      "duration": 200.0,
+      "type": "audio/mpeg"
+    }
+  ],
+
+  "metadata": {
+    "language": "en",
+    "title": "title",
+    "authors": [
+      "author_0",
+      "author_1",
+      "author_2"
+    ],
+    "duration": 1000.0,
+    "identifier": "urn:id"
+  }
+}


### PR DESCRIPTION
Manifests may contain spine items with null titles. Currently, the parser converts null to the string "null", which gets displayed in the UI. This allows the title to be null, so that the normal process for handling null values in the UI will work. Previously, this only worked when the title property was completely missing.

Once I get access to Jira again, I will attached ticket description here.