### PR TITLE
Explicitly handle nulls

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,8 @@ POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/audiobook-android.gi
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/audiobook-android.git
 POM_SCM_URL=https://github.com/NYPL-Simplified/audiobook-android
 POM_URL=https://github.com/NYPL-Simplified/audiobook-android
-VERSION_NAME=6.5.0
-VERSION_PREVIOUS=6.4.0
+VERSION_NAME=6.6.0
+VERSION_PREVIOUS=6.5.0
 
 android.useAndroidX=true
 android.enableJetifier=true

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerJSONParserUtilities.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerJSONParserUtilities.kt
@@ -30,6 +30,7 @@ import java.net.URISyntaxException
  * and exceptions are raised if the type is not exactly as expected.
  */
 
+@Deprecated("Use Jackson Databind or Fieldrush")
 class PlayerJSONParserUtilities private constructor() {
 
   companion object {
@@ -349,9 +350,32 @@ class PlayerJSONParserUtilities private constructor() {
       key: String
     ): String? {
 
-      return if (n.has(key)) {
-        getString(n, key)
-      } else null
+      val v = n[key] ?: return null
+      return when (v.nodeType) {
+        null,
+        NULL ->
+          null
+
+        ARRAY,
+        BINARY,
+        BOOLEAN,
+        MISSING,
+        NUMBER,
+        OBJECT,
+        POJO -> {
+          val sb = StringBuilder(128)
+          sb.append("Expected: A key '")
+          sb.append(key)
+          sb.append("' with a value of type String\n")
+          sb.append("Received: A value of type ")
+          sb.append(v.nodeType)
+          sb.append("\n")
+          throw PlayerJSONParseException(sb.toString())
+        }
+
+        STRING ->
+          v.asText()
+      }
     }
 
     /**

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerPositions.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerPositions.kt
@@ -56,8 +56,9 @@ object PlayerPositions : PlayerPositionParserType, PlayerPositionSerializerType 
     positionNode.put("chapter", position.chapter)
     positionNode.put("part", position.part)
     positionNode.put("offsetMilliseconds", position.offsetMilliseconds)
-    positionNode.put("title", position.title)
-
+    if (position.title != null) {
+      positionNode.put("title", position.title)
+    }
     node.set<ObjectNode>("position", positionNode)
     return node
   }

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerPositionParserSerializerContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/PlayerPositionParserSerializerContract.kt
@@ -141,4 +141,51 @@ abstract class PlayerPositionParserSerializerContract {
     Assert.assertEquals(137, resultNode.chapter)
     Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
   }
+
+  @Test
+  fun testNullTitle() {
+    val parser = createParser()
+    val serial = createSerializer()
+
+    val node = serial.serializeToObjectNode(
+      PlayerPosition(null, 23, 137, 183991238L)
+    )
+
+    val result =
+      parser.parseFromObjectNode(node)
+
+    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+
+    val resultNode = (result as Success<PlayerPosition, Exception>).result
+
+    Assert.assertEquals(null, resultNode.title)
+    Assert.assertEquals(23, resultNode.part)
+    Assert.assertEquals(137, resultNode.chapter)
+    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+  }
+
+  @Test
+  fun testNullTitleExplicit() {
+    val parser = createParser()
+    val serial = createSerializer()
+
+    val node = serial.serializeToObjectNode(
+      PlayerPosition("Something", 23, 137, 183991238L)
+    )
+
+    val objectNode = node["position"] as ObjectNode
+    objectNode.put("title", null as String?)
+
+    val result =
+      parser.parseFromObjectNode(node)
+
+    Assert.assertTrue(result is Success<PlayerPosition, Exception>)
+
+    val resultNode = (result as Success<PlayerPosition, Exception>).result
+
+    Assert.assertEquals(null, resultNode.title)
+    Assert.assertEquals(23, resultNode.part)
+    Assert.assertEquals(137, resultNode.chapter)
+    Assert.assertEquals(183991238L, resultNode.offsetMilliseconds)
+  }
 }


### PR DESCRIPTION
This updates the "getStringOptional" method to explicitly handle null
values. The entire JSON utilities class has been deprecated as it
only has a single consumer nowadays and most of the methods are unused.

This PR is one half of the work. This is the "make it stop throwing an exception"
work, whilst the other part will be "don't treat exceptions here as fatal" in the app.