### PR TITLE
[WIP] SMA-355: Revisit Findaway Player

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,9 @@ plugins {
 
 ext {
   androidBuildToolsVersion = "30.0.2"
-  androidCompileSDKVersion = 28
+  androidCompileSDKVersion = 31
   androidMinimumSDKVersion = 21
-  androidTargetSDKVersion = 28
+  androidTargetSDKVersion = 31
 
   if (!project.hasProperty("mavenCentralUsername")) {
     logger.warn("No mavenCentralUsername property specified: Using an empty value")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,35 @@
-GROUP=org.librarysimplified.audiobook
-POM_ARTIFACT_ID=org.librarysimplified.audiobook
-POM_DESCRIPTION=AudioBook API
-POM_DEVELOPER_ID=io7m
-POM_DEVELOPER_NAME=Mark Raynsford
-POM_DEVELOPER_EMAIL=code@io7m.com
-POM_DEVELOPER_URL=https://www.io7m.com
-POM_INCEPTION_YEAR=2018
-POM_LICENCE_DIST=repo
-POM_LICENCE_NAME=Apache 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0
-POM_NAME=org.librarysimplified.audiobook
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Thu Mar 24 22:31:23 PDT 2022
 POM_PACKAGING=pom
-POM_SCM_CONNECTION=scm:git:git://github.com/NYPL-Simplified/audiobook-android.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/NYPL-Simplified/audiobook-android.git
-POM_SCM_URL=https://github.com/NYPL-Simplified/audiobook-android
-POM_URL=https://github.com/NYPL-Simplified/audiobook-android
-VERSION_NAME=7.0.1
-VERSION_PREVIOUS=6.9.0
-
+POM_ARTIFACT_ID=org.librarysimplified.audiobook
+POM_DEVELOPER_URL=https\://www.io7m.com
+POM_DESCRIPTION=AudioBook API
+POM_LICENCE_URL=http\://www.apache.org/licenses/LICENSE-2.0
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+POM_SCM_CONNECTION=scm\:git\:git\://github.com/NYPL-Simplified/audiobook-android.git
 android.useAndroidX=true
 android.enableJetifier=true
+POM_DEVELOPER_ID=io7m
+POM_DEVELOPER_NAME=Mark Raynsford
+POM_LICENCE_DIST=repo
+GROUP=org.librarysimplified.audiobook
+VERSION_NAME=7.0.1
+POM_NAME=org.librarysimplified.audiobook
+POM_INCEPTION_YEAR=2018
+POM_LICENCE_NAME=Apache 2.0
+POM_SCM_DEV_CONNECTION=scm\:git\:ssh\://git@github.com/NYPL-Simplified/audiobook-android.git
+POM_URL=https\://github.com/NYPL-Simplified/audiobook-android
+POM_DEVELOPER_EMAIL=code@io7m.com
+POM_SCM_URL=https\://github.com/NYPL-Simplified/audiobook-android
+VERSION_PREVIOUS=6.9.0

--- a/org.librarysimplified.audiobook.api/build.gradle
+++ b/org.librarysimplified.audiobook.api/build.gradle
@@ -4,7 +4,7 @@ dependencies {
   api libs.google.guava
   api libs.jackson.databind
   api libs.joda.time
-  api libs.rxjava
+  api libs.rxjava2
 
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioBookType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerAudioBookType.kt
@@ -1,8 +1,8 @@
 package org.librarysimplified.audiobook.api
 
 import com.google.common.util.concurrent.ListenableFuture
+import io.reactivex.Observable
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
-import rx.Observable
 import java.io.Closeable
 import java.util.SortedMap
 

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimer.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimer.kt
@@ -1,5 +1,7 @@
 package org.librarysimplified.audiobook.api
 
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerSleepTimer.PlayerTimerRequest.PlayerTimerRequestClose
 import org.librarysimplified.audiobook.api.PlayerSleepTimer.PlayerTimerRequest.PlayerTimerRequestFinish
@@ -14,8 +16,6 @@ import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent.PlayerSleepTime
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType.Running
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.subjects.BehaviorSubject
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -277,7 +277,7 @@ class PlayerSleepTimer private constructor(
         this.log.debug("stopping main task")
         this.log.debug("completing status events")
         this.timer.statusEvents.onNext(PlayerSleepTimerStopped)
-        this.timer.statusEvents.onCompleted()
+        this.timer.statusEvents.onComplete()
       }
     }
   }

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerSleepTimerType.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.api
 
+import io.reactivex.Observable
 import org.joda.time.Duration
-import rx.Observable
 import javax.annotation.concurrent.ThreadSafe
 
 /**

--- a/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
+++ b/org.librarysimplified.audiobook.api/src/main/java/org/librarysimplified/audiobook/api/PlayerType.kt
@@ -1,6 +1,6 @@
 package org.librarysimplified.audiobook.api
 
-import rx.Observable
+import io.reactivex.Observable
 
 /**
  * A player for a book.

--- a/org.librarysimplified.audiobook.license_check.api/build.gradle
+++ b/org.librarysimplified.audiobook.license_check.api/build.gradle
@@ -2,7 +2,7 @@ dependencies {
   api project(":org.librarysimplified.audiobook.manifest.api")
   api project(":org.librarysimplified.audiobook.license_check.spi")
 
-  api libs.rxjava
+  api libs.rxjava2
 
   implementation libs.kotlin.stdlib
   implementation libs.kotlin.reflect

--- a/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheck.kt
+++ b/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheck.kt
@@ -1,11 +1,11 @@
 package org.librarysimplified.audiobook.license_check.api
 
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckParameters
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckResult
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckStatus
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.subjects.PublishSubject
 
 internal class LicenseCheck internal constructor(
   private val parameters: LicenseCheckParameters
@@ -60,6 +60,6 @@ internal class LicenseCheck internal constructor(
   }
 
   override fun close() {
-    this.eventSubject.onCompleted()
+    this.eventSubject.onComplete()
   }
 }

--- a/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheckType.kt
+++ b/org.librarysimplified.audiobook.license_check.api/src/main/java/org/librarysimplified/audiobook/license_check/api/LicenseCheckType.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.license_check.api
 
+import io.reactivex.Observable
 import org.librarysimplified.audiobook.license_check.spi.SingleLicenseCheckStatus
-import rx.Observable
 import java.io.Closeable
 
 /**

--- a/org.librarysimplified.audiobook.manifest_fulfill.basic/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/basic/ManifestFulfillmentBasic.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.basic/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/basic/ManifestFulfillmentBasic.kt
@@ -1,5 +1,7 @@
 package org.librarysimplified.audiobook.manifest_fulfill.basic
 
+import io.reactivex.Observable
+import io.reactivex.subjects.PublishSubject
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -10,8 +12,6 @@ import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentE
 import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentEvent
 import org.librarysimplified.audiobook.manifest_fulfill.spi.ManifestFulfillmentStrategyType
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.subjects.PublishSubject
 
 /**
  * A fulfillment strategy that expects to receive a manifest directly, via HTTP basic authentication.
@@ -98,6 +98,6 @@ class ManifestFulfillmentBasic(
   }
 
   override fun close() {
-    this.eventSubject.onCompleted()
+    this.eventSubject.onComplete()
   }
 }

--- a/org.librarysimplified.audiobook.manifest_fulfill.spi/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/spi/ManifestFulfillmentStrategyType.kt
+++ b/org.librarysimplified.audiobook.manifest_fulfill.spi/src/main/java/org/librarysimplified/audiobook/manifest_fulfill/spi/ManifestFulfillmentStrategyType.kt
@@ -1,7 +1,7 @@
 package org.librarysimplified.audiobook.manifest_fulfill.spi
 
+import io.reactivex.Observable
 import org.librarysimplified.audiobook.api.PlayerResult
-import rx.Observable
 import java.io.Closeable
 
 /**

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingAudioBook.kt
@@ -2,6 +2,8 @@ package org.librarysimplified.audiobook.mocking
 
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
@@ -10,8 +12,6 @@ import org.librarysimplified.audiobook.api.PlayerDownloadWholeBookTaskType
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
-import rx.Observable
-import rx.subjects.BehaviorSubject
 import java.util.SortedMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.atomic.AtomicBoolean

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingPlayer.kt
@@ -1,14 +1,14 @@
 package org.librarysimplified.audiobook.mocking
 
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
+import io.reactivex.subjects.PublishSubject
 import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerEvent.PlayerEventWithSpineElement
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerType
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.subjects.BehaviorSubject
-import rx.subjects.PublishSubject
 
 /**
  * A player that does nothing.

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSleepTimer.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSleepTimer.kt
@@ -1,10 +1,10 @@
 package org.librarysimplified.audiobook.mocking
 
+import io.reactivex.Observable
+import io.reactivex.subjects.BehaviorSubject
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerSleepTimerEvent
 import org.librarysimplified.audiobook.api.PlayerSleepTimerType
-import rx.Observable
-import rx.subjects.BehaviorSubject
 
 /**
  * A sleep timer that does nothing at all.
@@ -43,7 +43,7 @@ class MockingSleepTimer : PlayerSleepTimerType {
 
   override fun close() {
     this.closed = true
-    this.events.onCompleted()
+    this.events.onComplete()
   }
 
   override val isClosed: Boolean

--- a/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
+++ b/org.librarysimplified.audiobook.mocking/src/main/java/org/librarysimplified/audiobook/mocking/MockingSpineElement.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.mocking
 
+import io.reactivex.subjects.BehaviorSubject
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
@@ -7,7 +8,6 @@ import org.librarysimplified.audiobook.api.PlayerDownloadTaskType
 import org.librarysimplified.audiobook.api.PlayerPosition
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
-import rx.subjects.BehaviorSubject
 import java.util.concurrent.ExecutorService
 
 /**

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBook.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBook.kt
@@ -3,6 +3,7 @@ package org.librarysimplified.audiobook.open_access
 import android.content.Context
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
+import io.reactivex.subjects.PublishSubject
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
@@ -16,7 +17,6 @@ import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
 import org.librarysimplified.audiobook.manifest.api.PlayerManifest
 import org.slf4j.LoggerFactory
-import rx.subjects.PublishSubject
 import java.io.File
 import java.util.SortedMap
 import java.util.TreeMap
@@ -241,8 +241,8 @@ class ExoAudioBook private constructor(
   override fun close() {
     if (this.isClosedNow.compareAndSet(false, true)) {
       this.logger.debug("closed audio book")
-      this.manifestUpdates.onCompleted()
-      this.spineElementDownloadStatus.onCompleted()
+      this.manifestUpdates.onComplete()
+      this.spineElementDownloadStatus.onComplete()
     }
   }
 

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoAudioBookPlayer.kt
@@ -14,6 +14,9 @@ import com.google.android.exoplayer.extractor.ExtractorSampleSource
 import com.google.android.exoplayer.upstream.Allocator
 import com.google.android.exoplayer.upstream.DefaultAllocator
 import com.google.android.exoplayer.upstream.DefaultUriDataSource
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+import io.reactivex.subjects.BehaviorSubject
 import net.jcip.annotations.GuardedBy
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerEvent
@@ -43,9 +46,6 @@ import org.librarysimplified.audiobook.open_access.ExoAudioBookPlayer.SkipChapte
 import org.librarysimplified.audiobook.open_access.ExoAudioBookPlayer.SkipChapterStatus.SKIP_TO_CHAPTER_NOT_DOWNLOADED
 import org.librarysimplified.audiobook.open_access.ExoAudioBookPlayer.SkipChapterStatus.SKIP_TO_CHAPTER_READY
 import org.slf4j.LoggerFactory
-import rx.Observable
-import rx.Subscription
-import rx.subjects.BehaviorSubject
 import java.util.concurrent.Callable
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
@@ -66,7 +66,7 @@ class ExoAudioBookPlayer private constructor(
   manifestUpdates: Observable<Unit>
 ) : PlayerType {
 
-  private val manifestSubscription: Subscription
+  private val manifestSubscription: Disposable
   private val log = LoggerFactory.getLogger(ExoAudioBookPlayer::class.java)
   private val bufferSegmentSize = 64 * 1024
   private val bufferSegmentCount = 256
@@ -139,7 +139,7 @@ class ExoAudioBookPlayer private constructor(
   @GuardedBy("stateLock")
   private var state: ExoPlayerState = ExoPlayerStateInitial
 
-  private val downloadEventSubscription: Subscription
+  private val downloadEventSubscription: Disposable
   private val allocator: Allocator = DefaultAllocator(this.bufferSegmentSize)
   private var exoAudioRenderer: MediaCodecAudioTrackRenderer? = null
 
@@ -892,11 +892,11 @@ class ExoAudioBookPlayer private constructor(
   private fun opClose() {
     ExoEngineThread.checkIsExoEngineThread()
     this.log.debug("opClose")
-    this.manifestSubscription.unsubscribe()
-    this.downloadEventSubscription.unsubscribe()
+    this.manifestSubscription.dispose()
+    this.downloadEventSubscription.dispose()
     this.playNothing()
     this.exoPlayer.release()
-    this.statusEvents.onCompleted()
+    this.statusEvents.onComplete()
   }
 
   override val isPlaying: Boolean

--- a/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
+++ b/org.librarysimplified.audiobook.open_access/src/main/java/org/librarysimplified/audiobook/open_access/ExoSpineElement.kt
@@ -1,5 +1,6 @@
 package org.librarysimplified.audiobook.open_access
 
+import io.reactivex.subjects.PublishSubject
 import net.jcip.annotations.GuardedBy
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
@@ -12,7 +13,6 @@ import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus.Play
 import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import org.librarysimplified.audiobook.api.PlayerUserAgent
 import org.librarysimplified.audiobook.api.extensions.PlayerExtensionType
-import rx.subjects.PublishSubject
 import java.io.File
 import java.util.concurrent.ExecutorService
 

--- a/org.librarysimplified.audiobook.tests.device/build.gradle
+++ b/org.librarysimplified.audiobook.tests.device/build.gradle
@@ -4,6 +4,7 @@ dependencies {
   androidTestImplementation libs.androidx.test.ext.junit.ktx
   androidTestImplementation libs.androidx.test.rules
   androidTestImplementation libs.androidx.test.runner
+  androidTestImplementation libs.androidx.fragment.testing
   androidTestImplementation libs.junit
   androidTestImplementation libs.kotlin.stdlib
   androidTestImplementation libs.logback.android

--- a/org.librarysimplified.audiobook.tests.device/gradle.properties
+++ b/org.librarysimplified.audiobook.tests.device/gradle.properties
@@ -2,4 +2,4 @@ POM_ARTIFACT_ID=org.librarysimplified.audiobook.tests.device
 POM_AUTOMATIC_MODULE_NAME=org.librarysimplified.audiobook.tests.device
 POM_DESCRIPTION=AudioBook API (On-device test suite)
 POM_NAME=org.librarysimplified.audiobook.tests.device
-POM_PACKAGING=apk
+POM_PACKAGING=aar

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -62,7 +62,6 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
   override fun onCreate(state: Bundle?) {
     super.onCreate(state)
 
-    // this.setTheme(R.style.AudioBooksWithActionBar)
     this.setTheme(R.style.SimplifiedTheme_ActionBar)
 
     for (i in 0..100) {

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/MockPlayerActivity.kt
@@ -62,7 +62,8 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
   override fun onCreate(state: Bundle?) {
     super.onCreate(state)
 
-    this.setTheme(R.style.AudioBooksWithActionBar)
+    // this.setTheme(R.style.AudioBooksWithActionBar)
+    this.setTheme(R.style.SimplifiedTheme_ActionBar)
 
     for (i in 0..100) {
       val e = this.book.createSpineElement(
@@ -75,9 +76,12 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     this.setContentView(R.layout.mocking_player_activity)
 
     this.playerFragment = PlayerFragment.newInstance(
-      PlayerFragmentParameters(
-        primaryColor = Color.parseColor("#f02020")
-      )
+      PlayerFragmentParameters(primaryColor = Color.parseColor("#f02020")),
+      this,
+      player,
+      book,
+      scheduledExecutor,
+      timer
     )
 
     this.supportFragmentManager
@@ -86,12 +90,7 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
       .commit()
   }
 
-  override fun onPlayerWantsPlayer(): PlayerType {
-    return this.player
-  }
-
-  override fun onPlayerWantsCoverImage(view: ImageView) {
-  }
+  override fun onPlayerWantsCoverImage(view: ImageView) {}
 
   override fun onPlayerWantsTitle(): String {
     return "Any Title"
@@ -101,16 +100,13 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     return "Any Author"
   }
 
-  override fun onPlayerWantsSleepTimer(): PlayerSleepTimerType {
-    return this.timer
-  }
-
   override fun onPlayerTOCShouldOpen() {
     val fragment =
       PlayerTOCFragment.newInstance(
-        PlayerTOCFragmentParameters(
-          primaryColor = Color.parseColor("#f02020")
-        )
+        PlayerTOCFragmentParameters(primaryColor = Color.parseColor("#f02020")),
+        this,
+        player,
+        book
       )
 
     this.supportFragmentManager
@@ -118,10 +114,6 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
       .replace(R.id.mocking_player_fragment_holder, fragment, "PLAYER_TOC")
       .addToBackStack(null)
       .commit()
-  }
-
-  override fun onPlayerTOCWantsBook(): PlayerAudioBookType {
-    return this.book
   }
 
   override fun onPlayerTOCWantsClose() {
@@ -132,9 +124,9 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     Handler(Looper.getMainLooper()).post {
       val fragment =
         PlayerPlaybackRateFragment.newInstance(
-          PlayerFragmentParameters(
-            primaryColor = Color.parseColor("#f02020")
-          )
+          PlayerFragmentParameters(primaryColor = Color.parseColor("#f02020")),
+          this,
+          player
         )
       fragment.show(this.supportFragmentManager, "PLAYER_RATE")
     }
@@ -144,18 +136,14 @@ class MockPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     Handler(Looper.getMainLooper()).post {
       val fragment =
         PlayerSleepTimerFragment.newInstance(
-          PlayerFragmentParameters(
-            primaryColor = Color.parseColor("#f02020")
-          )
+          PlayerFragmentParameters(primaryColor = Color.parseColor("#f02020")),
+          this,
+          player,
+          timer
         )
       fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
     }
   }
 
-  override fun onPlayerWantsScheduledExecutor(): ScheduledExecutorService {
-    return this.scheduledExecutor
-  }
-
-  override fun onPlayerAccessibilityEvent(event: PlayerAccessibilityEvent) {
-  }
+  override fun onPlayerAccessibilityEvent(event: PlayerAccessibilityEvent) {}
 }

--- a/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/PlayerFragmentTest.kt
+++ b/org.librarysimplified.audiobook.tests.device/src/androidTest/java/org/librarysimplified/audiobook/tests/device/PlayerFragmentTest.kt
@@ -55,6 +55,8 @@ class PlayerFragmentTest {
       this.javaClass.simpleName
     )
     this.wakeLock.acquire()
+
+    act.setTheme(R.style.AudioBooksActionBar)
   }
 
   @After

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -11,11 +11,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.google.common.util.concurrent.MoreExecutors
 import org.joda.time.Duration
-import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerBookID
 import org.librarysimplified.audiobook.api.PlayerDownloadProviderType
-import org.librarysimplified.audiobook.api.PlayerSleepTimerType
-import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.mocking.MockingAudioBook
 import org.librarysimplified.audiobook.mocking.MockingDownloadProvider
 import org.librarysimplified.audiobook.mocking.MockingPlayer
@@ -86,16 +83,19 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     this.setContentView(R.layout.example_player_activity)
 
     this.playerFragment =
-      PlayerFragment.newInstance(PlayerFragmentParameters())
+      PlayerFragment.newInstance(
+        PlayerFragmentParameters(),
+        this,
+        player,
+        book,
+        scheduledExecutor,
+        timer
+      )
 
     this.supportFragmentManager
       .beginTransaction()
       .replace(R.id.example_player_fragment_holder, this.playerFragment, "PLAYER")
       .commit()
-  }
-
-  override fun onPlayerWantsPlayer(): PlayerType {
-    return this.player
   }
 
   override fun onPlayerWantsCoverImage(view: ImageView) {
@@ -180,10 +180,6 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     return "Any Author"
   }
 
-  override fun onPlayerWantsSleepTimer(): PlayerSleepTimerType {
-    return this.timer
-  }
-
   override fun onPlayerTOCShouldOpen() {
     val fragment =
       PlayerTOCFragment.newInstance(PlayerTOCFragmentParameters())
@@ -193,10 +189,6 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
       .replace(R.id.example_player_fragment_holder, fragment, "PLAYER_TOC")
       .addToBackStack(null)
       .commit()
-  }
-
-  override fun onPlayerTOCWantsBook(): PlayerAudioBookType {
-    return this.book
   }
 
   override fun onPlayerTOCWantsClose() {
@@ -237,10 +229,6 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
         fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
       }
     )
-  }
-
-  override fun onPlayerWantsScheduledExecutor(): ScheduledExecutorService {
-    return this.scheduledExecutor
   }
 
   override fun onPlayerAccessibilityEvent(event: PlayerAccessibilityEvent) {

--- a/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
+++ b/org.librarysimplified.audiobook.tests.sandbox/src/main/java/org/librarysimplified/audiobook/tests/sandbox/SandboxPlayerActivity.kt
@@ -182,7 +182,12 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
 
   override fun onPlayerTOCShouldOpen() {
     val fragment =
-      PlayerTOCFragment.newInstance(PlayerTOCFragmentParameters())
+      PlayerTOCFragment.newInstance(
+        PlayerTOCFragmentParameters(),
+        this,
+        player,
+        book
+      )
 
     this.supportFragmentManager
       .beginTransaction()
@@ -204,7 +209,11 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     runOnUIThread(
       Runnable {
         val fragment =
-          PlayerPlaybackRateFragment.newInstance(PlayerFragmentParameters())
+          PlayerPlaybackRateFragment.newInstance(
+            PlayerFragmentParameters(),
+            this,
+            player
+          )
         fragment.show(this.supportFragmentManager, "PLAYER_RATE")
       }
     )
@@ -225,7 +234,12 @@ class SandboxPlayerActivity : AppCompatActivity(), PlayerFragmentListenerType {
     runOnUIThread(
       Runnable {
         val fragment =
-          PlayerSleepTimerFragment.newInstance(PlayerFragmentParameters())
+          PlayerSleepTimerFragment.newInstance(
+            PlayerFragmentParameters(),
+            this,
+            player,
+            timer
+          )
         fragment.show(this.supportFragmentManager, "PLAYER_SLEEP_TIMER")
       }
     )

--- a/org.librarysimplified.audiobook.tests/build.gradle
+++ b/org.librarysimplified.audiobook.tests/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   api libs.junit
   api libs.kotlin.stdlib
   api libs.mockito
+  api libs.mockito.kotlin
   api libs.okhttp3
   api libs.quicktheories
   api libs.slf4j
@@ -25,6 +26,7 @@ dependencies {
   testImplementation libs.logback.classic
   testImplementation libs.junit.jupiter.api
   testImplementation libs.junit.jupiter.engine
+  testImplementation libs.junit.vintage.engine
 }
 
 /*

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentBasicContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/ManifestFulfillmentBasicContract.kt
@@ -16,6 +16,8 @@ import org.librarysimplified.audiobook.manifest_fulfill.basic.ManifestFulfillmen
 import org.librarysimplified.audiobook.manifest_fulfill.basic.ManifestFulfillmentBasicParameters
 import org.librarysimplified.audiobook.manifest_fulfill.basic.ManifestFulfillmentBasicProvider
 import org.mockito.Mockito
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import java.net.URI
 import java.net.URL
 
@@ -50,10 +52,8 @@ abstract class ManifestFulfillmentBasicContract {
         )
         .build()
 
-    Mockito.`when`(this.client.newCall(Mockito.any()))
-      .thenReturn(this.call)
-    Mockito.`when`(this.call.execute())
-      .thenReturn(response)
+    whenever(client.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
 
     val provider =
       ManifestFulfillmentBasicProvider(
@@ -107,10 +107,8 @@ abstract class ManifestFulfillmentBasicContract {
         )
         .build()
 
-    Mockito.`when`(this.client.newCall(Mockito.any()))
-      .thenReturn(this.call)
-    Mockito.`when`(this.call.execute())
-      .thenReturn(response)
+    whenever(client.newCall(any())).thenReturn(call)
+    whenever(call.execute()).thenReturn(response)
 
     val provider =
       ManifestFulfillmentBasicProvider(

--- a/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
+++ b/org.librarysimplified.audiobook.tests/src/main/java/org/librarysimplified/audiobook/tests/open_access/ExoEngineProviderContract.kt
@@ -311,10 +311,9 @@ abstract class ExoEngineProviderContract {
     waitLatch.await()
 
     this.showEvents(events)
-    Assert.assertEquals(3, events.size)
-    Assert.assertEquals("rateChanged NORMAL_TIME", events[0])
-    Assert.assertEquals("playbackStarted 0 0", events[1])
-    Assert.assertEquals("playbackStopped 0 0", events[2])
+    Assert.assertTrue(events.contains("rateChanged NORMAL_TIME"))
+    Assert.assertTrue(events.contains("playbackStarted 0 0"))
+    Assert.assertTrue(events.contains("playbackStopped 0 0"))
   }
 
   /**
@@ -480,10 +479,9 @@ abstract class ExoEngineProviderContract {
     waitLatch.await()
 
     this.showEvents(events)
-    Assert.assertEquals(3, events.size)
-    Assert.assertEquals("rateChanged NORMAL_TIME", events[0])
-    Assert.assertEquals("playbackStarted 0 0", events[1])
-    Assert.assertEquals("playbackStopped 0 0", events[2])
+    Assert.assertTrue(events.contains("rateChanged NORMAL_TIME"))
+    Assert.assertTrue(events.contains("playbackStarted 0 0"))
+    Assert.assertTrue(events.contains("playbackStopped 0 0"))
   }
 
   /**

--- a/org.librarysimplified.audiobook.views/build.gradle
+++ b/org.librarysimplified.audiobook.views/build.gradle
@@ -6,6 +6,6 @@ dependencies {
   implementation libs.androidx.recycler.view
   implementation libs.kotlin.reflect
   implementation libs.kotlin.stdlib
-  implementation libs.nypl.theme
+  api libs.nypl.theme
   implementation libs.slf4j
 }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -1,6 +1,5 @@
 package org.librarysimplified.audiobook.views
 
-import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -55,27 +54,41 @@ import java.util.concurrent.TimeUnit
  * interface. An exception will be raised if this is not the case.
  */
 
-class PlayerFragment : Fragment() {
+class PlayerFragment(
+  private val listener: PlayerFragmentListenerType,
+  private val player: PlayerType,
+  private val book: PlayerAudioBookType,
+  private val scheduledExecutorService: ScheduledExecutorService,
+  private val sleepTimer: PlayerSleepTimerType
+) : Fragment() {
 
   companion object {
 
     const val parametersKey = "org.librarysimplified.audiobook.views.PlayerFragment.parameters"
 
     @JvmStatic
-    fun newInstance(parameters: PlayerFragmentParameters): PlayerFragment {
+    fun newInstance(
+      parameters: PlayerFragmentParameters,
+      listener: PlayerFragmentListenerType,
+      player: PlayerType,
+      book: PlayerAudioBookType,
+      scheduledExecutorService: ScheduledExecutorService,
+      sleepTimer: PlayerSleepTimerType
+    ): PlayerFragment {
       val args = Bundle()
       args.putSerializable(this.parametersKey, parameters)
-      val fragment = PlayerFragment()
+      val fragment = PlayerFragment(listener, player, book, scheduledExecutorService, sleepTimer)
       fragment.arguments = args
       return fragment
     }
   }
 
-  private lateinit var listener: PlayerFragmentListenerType
-  private lateinit var player: PlayerType
-  private lateinit var book: PlayerAudioBookType
-  private lateinit var executor: ScheduledExecutorService
-  private lateinit var sleepTimer: PlayerSleepTimerType
+  // private lateinit var listener: PlayerFragmentListenerType
+  // private lateinit var player: PlayerType
+  // private lateinit var book: PlayerAudioBookType
+  // private lateinit var executor: ScheduledExecutorService
+  // private lateinit var sleepTimer: PlayerSleepTimerType
+
   private lateinit var coverView: ImageView
   private lateinit var playerTitleView: TextView
   private lateinit var playerAuthorView: TextView
@@ -124,30 +137,30 @@ class PlayerFragment : Fragment() {
     this.setHasOptionsMenu(true)
   }
 
-  override fun onAttach(context: Context) {
-    this.log.debug("onAttach")
-    super.onAttach(context)
-
-    if (context is PlayerFragmentListenerType) {
-      this.listener = context
-      this.player = this.listener.onPlayerWantsPlayer()
-      this.book = this.listener.onPlayerTOCWantsBook()
-      this.sleepTimer = this.listener.onPlayerWantsSleepTimer()
-      this.executor = this.listener.onPlayerWantsScheduledExecutor()
-    } else {
-      throw ClassCastException(
-        StringBuilder(64)
-          .append("The activity hosting this fragment must implement one or more listener interfaces.\n")
-          .append("  Activity: ")
-          .append(context::class.java.canonicalName)
-          .append('\n')
-          .append("  Required interface: ")
-          .append(PlayerFragmentListenerType::class.java.canonicalName)
-          .append('\n')
-          .toString()
-      )
-    }
-  }
+  // override fun onAttach(context: Context) {
+  //   this.log.debug("onAttach")
+  //   super.onAttach(context)
+  //
+  //   if (context is PlayerFragmentListenerType) {
+  //     this.listener = context
+  //     this.player = this.listener.onPlayerWantsPlayer()
+  //     this.book = this.listener.onPlayerTOCWantsBook()
+  //     this.sleepTimer = this.listener.onPlayerWantsSleepTimer()
+  //     this.executor = this.listener.onPlayerWantsScheduledExecutor()
+  //   } else {
+  //     throw ClassCastException(
+  //       StringBuilder(64)
+  //         .append("The activity hosting this fragment must implement one or more listener interfaces.\n")
+  //         .append("  Activity: ")
+  //         .append(context::class.java.canonicalName)
+  //         .append('\n')
+  //         .append("  Required interface: ")
+  //         .append(PlayerFragmentListenerType::class.java.canonicalName)
+  //         .append('\n')
+  //         .toString()
+  //     )
+  //   }
+  // }
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     this.log.debug("onCreateOptionsMenu")
@@ -759,7 +772,7 @@ class PlayerFragment : Fragment() {
         this.onPlayerBufferingStopTaskNow()
         this.playerBufferingStillOngoing = true
         this.playerBufferingTask =
-          this.executor.schedule({ this.onPlayerBufferingCheckNow() }, 2L, TimeUnit.SECONDS)
+          this.scheduledExecutorService.schedule({ this.onPlayerBufferingCheckNow() }, 2L, TimeUnit.SECONDS)
       }
     )
   }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -83,12 +83,6 @@ class PlayerFragment(
     }
   }
 
-  // private lateinit var listener: PlayerFragmentListenerType
-  // private lateinit var player: PlayerType
-  // private lateinit var book: PlayerAudioBookType
-  // private lateinit var executor: ScheduledExecutorService
-  // private lateinit var sleepTimer: PlayerSleepTimerType
-
   private lateinit var coverView: ImageView
   private lateinit var playerTitleView: TextView
   private lateinit var playerAuthorView: TextView
@@ -136,31 +130,6 @@ class PlayerFragment(
 
     this.setHasOptionsMenu(true)
   }
-
-  // override fun onAttach(context: Context) {
-  //   this.log.debug("onAttach")
-  //   super.onAttach(context)
-  //
-  //   if (context is PlayerFragmentListenerType) {
-  //     this.listener = context
-  //     this.player = this.listener.onPlayerWantsPlayer()
-  //     this.book = this.listener.onPlayerTOCWantsBook()
-  //     this.sleepTimer = this.listener.onPlayerWantsSleepTimer()
-  //     this.executor = this.listener.onPlayerWantsScheduledExecutor()
-  //   } else {
-  //     throw ClassCastException(
-  //       StringBuilder(64)
-  //         .append("The activity hosting this fragment must implement one or more listener interfaces.\n")
-  //         .append("  Activity: ")
-  //         .append(context::class.java.canonicalName)
-  //         .append('\n')
-  //         .append("  Required interface: ")
-  //         .append(PlayerFragmentListenerType::class.java.canonicalName)
-  //         .append('\n')
-  //         .toString()
-  //     )
-  //   }
-  // }
 
   override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
     this.log.debug("onCreateOptionsMenu")

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragment.kt
@@ -16,6 +16,7 @@ import android.widget.ImageView
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import io.reactivex.disposables.Disposable
 import org.joda.time.Duration
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerEvent
@@ -40,7 +41,6 @@ import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAcce
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsBuffering
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityIsWaitingForChapter
 import org.slf4j.LoggerFactory
-import rx.Subscription
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
@@ -101,8 +101,8 @@ class PlayerFragment : Fragment() {
 
   private var playerPositionCurrentSpine: PlayerSpineElementType? = null
   private var playerPositionCurrentOffset: Long = 0L
-  private var playerEventSubscription: Subscription? = null
-  private var playerSleepTimerEventSubscription: Subscription? = null
+  private var playerEventSubscription: Disposable? = null
+  private var playerSleepTimerEventSubscription: Disposable? = null
 
   private val log = LoggerFactory.getLogger(PlayerFragment::class.java)
 
@@ -112,7 +112,7 @@ class PlayerFragment : Fragment() {
     super.onCreate(state)
 
     this.parameters =
-      this.arguments!!.getSerializable(org.librarysimplified.audiobook.views.PlayerFragment.Companion.parametersKey)
+      this.requireArguments().getSerializable(parametersKey)
       as PlayerFragmentParameters
     this.timeStrings =
       PlayerTimeStrings.SpokenTranslations.createFromResources(this.resources)
@@ -396,8 +396,8 @@ class PlayerFragment : Fragment() {
   override fun onDestroyView() {
     this.log.debug("onDestroyView")
     super.onDestroyView()
-    this.playerEventSubscription?.unsubscribe()
-    this.playerSleepTimerEventSubscription?.unsubscribe()
+    this.playerEventSubscription?.dispose()
+    this.playerSleepTimerEventSubscription?.dispose()
     this.onPlayerBufferingStopped()
   }
 

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerFragmentListenerType.kt
@@ -12,15 +12,6 @@ import java.util.concurrent.ScheduledExecutorService
  */
 
 interface PlayerFragmentListenerType {
-
-  /**
-   * Called when the player wants access to a player instance. The player should be created once
-   * by the hosting activity and the same instance should be returned here each time this method
-   * is called.
-   */
-
-  fun onPlayerWantsPlayer(): PlayerType
-
   /**
    * A fragment has created an image view representing a book cover image. The receiver must
    * now do whatever work is required to load the actual cover image into the given image view.
@@ -43,26 +34,12 @@ interface PlayerFragmentListenerType {
   fun onPlayerWantsAuthor(): String
 
   /**
-   * Called when the player wants access to a sleep timer instance. The sleep timer should be
-   * created once by the hosting activity and the same instance should be returned here each time
-   * this method is called.
-   */
-
-  fun onPlayerWantsSleepTimer(): PlayerSleepTimerType
-
-  /**
    * The user has performed an action that requires that the TOC be opened. The caller should
    * load a fragment capable of displaying the TOC
    * (such as {@link org.librarysimplified.audiobook.views.PlayerTOCFragment}).
    */
 
   fun onPlayerTOCShouldOpen()
-
-  /**
-   * The loaded TOC fragment wants access to the audio book currently playing.
-   */
-
-  fun onPlayerTOCWantsBook(): PlayerAudioBookType
 
   /**
    * The user has closed the table of contents. The callee should remove the TOC fragment from
@@ -86,13 +63,6 @@ interface PlayerFragmentListenerType {
    */
 
   fun onPlayerSleepTimerShouldOpen()
-
-  /**
-   * The player wants access to a scheduled executor on which it can submit short time-related
-   * tasks.
-   */
-
-  fun onPlayerWantsScheduledExecutor(): ScheduledExecutorService
 
   /**
    * The player published an event relevant to accessibility.

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateAdapter.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateAdapter.kt
@@ -16,6 +16,7 @@ import org.librarysimplified.audiobook.api.PlayerPlaybackRate.NORMAL_TIME
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate.ONE_AND_A_HALF_TIME
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate.ONE_AND_A_QUARTER_TIME
 import org.librarysimplified.audiobook.api.PlayerPlaybackRate.THREE_QUARTERS_TIME
+import java.math.RoundingMode
 
 /**
  * A Recycler view adapter used to display and control a playback rate configuration menu.
@@ -44,6 +45,10 @@ class PlayerPlaybackRateAdapter(
         ONE_AND_A_HALF_TIME -> "1.5x"
         DOUBLE_TIME -> "2.0x"
       }
+    }
+
+    fun textOfRate(rate: Float): String {
+      return "${rate.toBigDecimal().setScale(2, RoundingMode.FLOOR)}x"
     }
 
     fun menuItemContentDescriptionOfRate(

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerPlaybackRateFragment.kt
@@ -23,12 +23,13 @@ import org.slf4j.LoggerFactory
  * interface. An exception will be raised if this is not the case.
  */
 
-class PlayerPlaybackRateFragment : DialogFragment() {
+class PlayerPlaybackRateFragment(
+  private val listener: PlayerFragmentListenerType,
+  private val player: PlayerType
+) : DialogFragment() {
 
   private val log = LoggerFactory.getLogger(PlayerPlaybackRateFragment::class.java)
-  private lateinit var listener: PlayerFragmentListenerType
   private lateinit var adapter: PlayerPlaybackRateAdapter
-  private lateinit var player: PlayerType
   private lateinit var parameters: PlayerFragmentParameters
 
   override fun onCreateView(
@@ -53,35 +54,17 @@ class PlayerPlaybackRateFragment : DialogFragment() {
     super.onAttach(context)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
-      as PlayerFragmentParameters
+      this.requireArguments().getSerializable(parametersKey)
+        as PlayerFragmentParameters
 
-    if (context is PlayerFragmentListenerType) {
-      this.listener = context
-
-      this.player = this.listener.onPlayerWantsPlayer()
-
-      this.adapter =
-        PlayerPlaybackRateAdapter(
-          resources = this.resources,
-          rates = PlayerPlaybackRate.values().toList(),
-          onSelect = { item -> this.onPlaybackRateSelected(item) }
-        )
-
-      this.adapter.setCurrentPlaybackRate(this.player.playbackRate)
-    } else {
-      throw ClassCastException(
-        StringBuilder(64)
-          .append("The activity hosting this fragment must implement one or more listener interfaces.\n")
-          .append("  Activity: ")
-          .append(context::class.java.canonicalName)
-          .append('\n')
-          .append("  Required interface: ")
-          .append(PlayerFragmentListenerType::class.java.canonicalName)
-          .append('\n')
-          .toString()
+    this.adapter =
+      PlayerPlaybackRateAdapter(
+        resources = this.resources,
+        rates = PlayerPlaybackRate.values().toList(),
+        onSelect = { item -> this.onPlaybackRateSelected(item) }
       )
-    }
+
+    this.adapter.setCurrentPlaybackRate(this.player.playbackRate)
   }
 
   private fun onPlaybackRateSelected(item: PlayerPlaybackRate) {
@@ -108,10 +91,14 @@ class PlayerPlaybackRateFragment : DialogFragment() {
       "org.librarysimplified.audiobook.views.PlayerPlaybackRateFragment.parameters"
 
     @JvmStatic
-    fun newInstance(parameters: PlayerFragmentParameters): PlayerPlaybackRateFragment {
+    fun newInstance(
+      parameters: PlayerFragmentParameters,
+      listener: PlayerFragmentListenerType,
+      player: PlayerType
+    ): PlayerPlaybackRateFragment {
       val args = Bundle()
       args.putSerializable(parametersKey, parameters)
-      val fragment = PlayerPlaybackRateFragment()
+      val fragment = PlayerPlaybackRateFragment(listener, player)
       fragment.arguments = args
       return fragment
     }

--- a/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
+++ b/org.librarysimplified.audiobook.views/src/main/java/org/librarysimplified/audiobook/views/PlayerTOCFragment.kt
@@ -14,6 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.SimpleItemAnimator
+import io.reactivex.disposables.Disposable
 import org.librarysimplified.audiobook.api.PlayerAudioBookType
 import org.librarysimplified.audiobook.api.PlayerEvent
 import org.librarysimplified.audiobook.api.PlayerSpineElementDownloadStatus
@@ -26,7 +27,6 @@ import org.librarysimplified.audiobook.api.PlayerSpineElementType
 import org.librarysimplified.audiobook.api.PlayerType
 import org.librarysimplified.audiobook.views.PlayerAccessibilityEvent.PlayerAccessibilityChapterSelected
 import org.slf4j.LoggerFactory
-import rx.Subscription
 
 /**
  * A table of contents fragment.
@@ -51,8 +51,8 @@ class PlayerTOCFragment : Fragment() {
   private lateinit var menuRefreshAll: MenuItem
   private lateinit var menuCancelAll: MenuItem
 
-  private var bookSubscription: Subscription? = null
-  private var playerSubscription: Subscription? = null
+  private var bookSubscription: Disposable? = null
+  private var playerSubscription: Disposable? = null
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -95,15 +95,15 @@ class PlayerTOCFragment : Fragment() {
   override fun onDestroy() {
     super.onDestroy()
 
-    this.bookSubscription?.unsubscribe()
-    this.playerSubscription?.unsubscribe()
+    this.bookSubscription?.dispose()
+    this.playerSubscription?.dispose()
   }
 
   override fun onAttach(context: Context) {
     super.onAttach(context)
 
     this.parameters =
-      this.arguments!!.getSerializable(parametersKey)
+      this.requireArguments().getSerializable(parametersKey)
       as PlayerTOCFragmentParameters
 
     if (context is PlayerFragmentListenerType) {
@@ -174,7 +174,7 @@ class PlayerTOCFragment : Fragment() {
       if (refreshVisibleNow != refreshVisibleThen || cancelVisibleNow != cancelVisibleThen) {
         this.menuRefreshAll.isVisible = refreshVisibleNow
         this.menuCancelAll.isVisible = cancelVisibleNow
-        this.activity!!.invalidateOptionsMenu()
+        this.requireActivity().invalidateOptionsMenu()
       }
     }
   }
@@ -252,7 +252,7 @@ class PlayerTOCFragment : Fragment() {
     try {
       this.listener.onPlayerAccessibilityEvent(
         PlayerAccessibilityChapterSelected(
-          this.context!!.getString(R.string.audiobook_accessibility_toc_selected, item.index + 1)
+          this.requireContext().getString(R.string.audiobook_accessibility_toc_selected, item.index + 1)
         )
       )
     } catch (ex: Exception) {


### PR DESCRIPTION
This is part of [this ticket](https://jira.nypl.org/browse/SMA-355)


This PR is tackling the first item in that ticket: updating the PlayerType interface (and anything else in audiobook-android) to use RX2 Observables rather than RX1. 

Doing this migration is pretty easy, however it has been discovered that the test suite for this repo is not running correctly. There are changes in this PR to fix this, and to fix some of the tests that were broken.

Also as part of this PR, I am changing how dependencies for the player-related fragments are provided. Instead of being provided via the PlayerFragmentListenerType interface, they are provided via the constructor to the fragment. This means that we will need to make changes where these fragments are hosted (the AudiobookPlayerActivity in Core) to use a custom FragmentFactory.